### PR TITLE
Use Golang 1.13 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ os:
 matrix:
   exclude:
     - os: osx
-      go: "1.11"
+      go: "1.12"
     - os: osx
       go: tip
 
 go:
-  - "1.11"
   - "1.12"
+  - "1.13"
   - tip
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
       GOROOT: c:\go-x86
       GOARCH: 386
 
-stack: go 1.11
+stack: go 1.13
 
 before_test:
   - set GOARCH=%GOARCH%


### PR DESCRIPTION
Bump up golang versions which are used in CI.