### PR TITLE
Support timezone parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ make
 | Endpoint         | Specify the endpoint URL      | `""`          | URL with port or empty string   |
 | AutoCreateBucket | Create bucket automatically   | `false`       | true/false                      |
 | LogLevel         | Specify Log Level             | `"info"`      | trace/debug/info/warning/error/fatal/panic     |
+| TimeZone         | Specify TimeZone              | `""`          | Specify TZInfo based region. e.g.) Asia/Tokyo     |
 
 Example:
 
@@ -95,6 +96,7 @@ Add this section to fluent-bit.conf:
     Compress gzip
     # Endpoint parameter is mainly used for minio.
     # Endpoint http://localhost:9000
+    # TimeZone Asia/Tokyo
 ```
 
 fluent-bit-go-s3 supports the following credentials. Users must specify one of them:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or,
 $ docker build . -t fluent-bit/s3-plugin
 ```
 
-and then, specify Url parameter as environment variables:
+and then, specify configuration parameters as environment variables:
 
 ```bash
 $ docker run -it -e="FLUENT_BIT_ACCESS_KEY_ID=yourawsaccesskey" \

--- a/out_s3_test.go
+++ b/out_s3_test.go
@@ -163,6 +163,7 @@ type testFluentPlugin struct {
 	endpoint         string
 	autoCreateBucket string
 	logLevel         string
+	location         string
 	records          []testrecord
 	position         int
 	events           []*events
@@ -190,6 +191,8 @@ func (p *testFluentPlugin) PluginConfigKey(ctx unsafe.Pointer, key string) strin
 		return p.autoCreateBucket
 	case "LogLevel":
 		return p.logLevel
+	case "TimeZone":
+		return p.location
 	}
 	return "unknown-" + key
 }
@@ -249,7 +252,7 @@ func (c *testS3Credential) GetCredentials(accessID, secretkey, credential string
 
 func TestPluginInitializationWithStaticCredentials(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "examplebucket", "exampleregion", "", "", "false", "info")
+	_, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "examplebucket", "exampleregion", "", "", "false", "info", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -270,7 +273,7 @@ func TestPluginInitializationWithStaticCredentials(t *testing.T) {
 
 func TestPluginInitializationWithSharedCredentials(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "", "", "false", "info")
+	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "", "", "false", "info", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}

--- a/out_s3_test.go
+++ b/out_s3_test.go
@@ -101,6 +101,51 @@ func TestGenerateObjectKey(t *testing.T) {
 	assert.NotNil(t, objectKey, "objectKey not to be nil")
 }
 
+func TestGenerateObjectKeyWithTokyoLocation(t *testing.T) {
+	now := time.Now()
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	s3mock := &s3operator{
+		bucket:         "s3examplebucket",
+		prefix:         "s3exampleprefix",
+		uploader:       nil,
+		compressFormat: plainTextFormat,
+		location:       loc,
+	}
+	objectKey := GenerateObjectKey(s3mock, now)
+	fmt.Printf("objectKey: %v\n", objectKey)
+	assert.NotNil(t, objectKey, "objectKey not to be nil")
+}
+
+func TestGenerateObjectKeyWithUSEastLocation(t *testing.T) {
+	now := time.Now()
+	loc, _ := time.LoadLocation("US/Eastern")
+	s3mock := &s3operator{
+		bucket:         "s3examplebucket",
+		prefix:         "s3exampleprefix",
+		uploader:       nil,
+		compressFormat: plainTextFormat,
+		location:       loc,
+	}
+	objectKey := GenerateObjectKey(s3mock, now)
+	fmt.Printf("objectKey: %v\n", objectKey)
+	assert.NotNil(t, objectKey, "objectKey not to be nil")
+}
+
+func TestGenerateObjectKeyWithUTCLocation(t *testing.T) {
+	now := time.Now()
+	loc, _ := time.LoadLocation("UTC")
+	s3mock := &s3operator{
+		bucket:         "s3examplebucket",
+		prefix:         "s3exampleprefix",
+		uploader:       nil,
+		compressFormat: plainTextFormat,
+		location:       loc,
+	}
+	objectKey := GenerateObjectKey(s3mock, now)
+	fmt.Printf("objectKey: %v\n", objectKey)
+	assert.NotNil(t, objectKey, "objectKey not to be nil")
+}
+
 func TestGenerateObjectKeyWithGzip(t *testing.T) {
 	now := time.Now()
 	s3mock := &s3operator{

--- a/s3.go
+++ b/s3.go
@@ -123,8 +123,11 @@ func getS3Config(accessID, secretKey, credential, s3prefix, bucket, region, comp
 		loc, err := time.LoadLocation(timeZone)
 		if err != nil {
 			return nil, fmt.Errorf("invalid timeZone: %v", err)
+		} else {
+			conf.location = loc
 		}
-		conf.location = loc
+	} else {
+		conf.location = time.Local
 	}
 
 	return conf, nil

--- a/s3.go
+++ b/s3.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type format int
@@ -25,6 +26,7 @@ type s3Config struct {
 	compress         format
 	endpoint         string
 	logLevel         log.Level
+	location         *time.Location
 	autoCreateBucket bool
 }
 
@@ -64,7 +66,7 @@ func (c *s3PluginConfig) GetCredentials(accessKeyID, secretKey, credential strin
 	return nil, fmt.Errorf("Failed to create credentials")
 }
 
-func getS3Config(accessID, secretKey, credential, s3prefix, bucket, region, compress, endpoint, autoCreateBucket, logLevel string) (*s3Config, error) {
+func getS3Config(accessID, secretKey, credential, s3prefix, bucket, region, compress, endpoint, autoCreateBucket, logLevel, timeZone string) (*s3Config, error) {
 	conf := &s3Config{}
 	creds, err := s3Creds.GetCredentials(accessID, secretKey, credential)
 	if err != nil {
@@ -116,6 +118,14 @@ func getS3Config(accessID, secretKey, credential, s3prefix, bucket, region, comp
 		return nil, fmt.Errorf("invalid log level: %v", logLevel)
 	}
 	conf.logLevel = level
+
+	if timeZone != "" {
+		loc, err := time.LoadLocation(timeZone)
+		if err != nil {
+			return nil, fmt.Errorf("invalid timeZone: %v", err)
+		}
+		conf.location = loc
+	}
 
 	return conf, nil
 }

--- a/s3_test.go
+++ b/s3_test.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	// "time"
+	"time"
 )
 
 func TestGetS3ConfigStaticCredentials(t *testing.T) {
-	conf, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "examplebucket", "exampleregion", "", "", "", "")
+	conf, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "examplebucket", "exampleregion", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -23,7 +23,7 @@ func TestGetS3ConfigStaticCredentials(t *testing.T) {
 
 func TestGetS3ConfigSharedCredentials(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "", "", "", "")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -38,7 +38,7 @@ func TestGetS3ConfigSharedCredentials(t *testing.T) {
 
 func TestGetS3ConfigCompression(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -53,7 +53,7 @@ func TestGetS3ConfigCompression(t *testing.T) {
 
 func TestGetS3ConfigEndpoint(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "http://localhost:9000", "false", "")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "http://localhost:9000", "false", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -69,9 +69,35 @@ func TestGetS3ConfigEndpoint(t *testing.T) {
 
 func TestGetS3ConfigInvalidEndpoint(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "https://your-bucketname.s3.amazonaws.com", "false", "")
+	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "https://your-bucketname.s3.amazonaws.com", "false", "", "")
 	if err != nil {
 		expected := errors.New("Endpoint is not supported for AWS S3. This parameter is intended for S3 compatible services. Use Region instead.")
+		assert.Equal(t, expected, err)
+	}
+}
+
+func TestGetS3ConfigTimeZone(t *testing.T) {
+	s3Creds = &testS3Credential{}
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("failed test %#v", err)
+	}
+
+	assert.Equal(t, "examplebucket", *conf.bucket, "Specify bucket name")
+	assert.Equal(t, "exampleprefix", *conf.s3prefix, "Specify s3prefix name")
+	assert.NotNil(t, conf.credentials, "credentials not to be nil")
+	assert.Equal(t, "exampleregion", *conf.region, "Specify s3prefix name")
+	assert.Equal(t, gzipFormat, conf.compress, "Specify compression method")
+	assert.Equal(t, false, conf.autoCreateBucket, "Specify true/false")
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	assert.Equal(t, loc, conf.location, "Specify valid TimeZone")
+}
+
+func TestGetS3ConfigInvalidTimeZone(t *testing.T) {
+	s3Creds = &testS3Credential{}
+	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "Asia/Nonexistent")
+	if err != nil {
+		expected := errors.New("invalid timeZone: unknown time zone Asia/Nonexistent")
 		assert.Equal(t, expected, err)
 	}
 }


### PR DESCRIPTION
fluent-bit-go-s3 plugin uses local time zone by default, but it sometimes fails to send events with correct time like as using Docker container.