### PR TITLE
Support IRSA

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  digest = "1:4538fa77bf2ba9e4c1e2a4c00666093bd81f537cc72874267c19a93d2ee8c00f"
+  digest = "1:ac3702beb056a0be3d3f55cf5499e00c2080912356b1a894e4548649ffcb02fc"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -24,6 +24,7 @@
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/context",
     "internal/ini",
     "internal/s3err",
     "internal/sdkio",
@@ -31,6 +32,8 @@
     "internal/sdkrand",
     "internal/sdkuri",
     "internal/shareddefaults",
+    "internal/strings",
+    "internal/sync/singleflight",
     "private/protocol",
     "private/protocol/eventstream",
     "private/protocol/eventstream/eventstreamapi",
@@ -48,8 +51,8 @@
     "service/sts/stsiface",
   ]
   pruneopts = "UT"
-  revision = "fcbfc357f185c1d55e2c37626357ec92abd52286"
-  version = "v1.26.8"
+  revision = "a42d0a97783a46513ce37a77190029a78d7b6090"
+  version = "v1.29.31"
 
 [[projects]]
   digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.19.30"
+  version = "1.29.31"
 
 [[constraint]]
   branch = "mark-nocheckptr"

--- a/out_s3.go
+++ b/out_s3.go
@@ -198,15 +198,21 @@ func newS3Output(ctx unsafe.Pointer, operatorID int) (*s3operator, error) {
 	logger.Infof("[flb-go %d] plugin autoCreateBucket parameter = '%s'", operatorID, autoCreateBucket)
 	logger.Infof("[flb-go %d] plugin timeZone parameter = '%s'", operatorID, timeZone)
 
+
 	cfg := aws.Config{
-		Credentials: config.credentials,
 		Region:      config.region,
+	}
+	if config.credentials != nil {
+		cfg.WithCredentials(config.credentials)
 	}
 	if config.endpoint != "" {
 		cfg.WithEndpoint(config.endpoint).WithS3ForcePathStyle(true)
 	}
 
-	sess := session.New(&cfg)
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		Config: cfg,
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
 	if config.autoCreateBucket == true {
 		_, err = ensureBucket(sess, config.bucket, config.region)

--- a/s3.go
+++ b/s3.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/aws/aws-sdk-go/aws"
+import (
+	"github.com/aws/aws-sdk-go/aws"
+)
 import "github.com/aws/aws-sdk-go/aws/credentials"
 import log "github.com/sirupsen/logrus"
 
@@ -39,31 +41,22 @@ type s3PluginConfig struct{}
 var s3Creds S3Credential = &s3PluginConfig{}
 
 func (c *s3PluginConfig) GetCredentials(accessKeyID, secretKey, credential string) (*credentials.Credentials, error) {
-	var creds *credentials.Credentials
 	if credential != "" {
-		creds = credentials.NewSharedCredentials(credential, "default")
+		creds := credentials.NewSharedCredentials(credential, "default")
 		if _, err := creds.Get(); err != nil {
-			fmt.Println("[SharedCredentials] ERROR:", err)
-		} else {
-			return creds, nil
+			return nil, fmt.Errorf("[SharedCredentials] ERROR: %s", err)
 		}
-	} else if !(accessKeyID == "" && secretKey == "") {
-		creds = credentials.NewStaticCredentials(accessKeyID, secretKey, "")
-		if _, err := creds.Get(); err != nil {
-			fmt.Println("[StaticCredentials] ERROR:", err)
-		} else {
-			return creds, nil
-		}
-	} else {
-		creds = credentials.NewEnvCredentials()
-		if _, err := creds.Get(); err != nil {
-			fmt.Println("[EnvCredentials] ERROR:", err)
-		} else {
-			return creds, nil
-		}
+		return creds, nil
 	}
+	if !(accessKeyID == "" && secretKey == "") {
+		creds := credentials.NewStaticCredentials(accessKeyID, secretKey, "")
+		if _, err := creds.Get(); err != nil {
+			return nil, fmt.Errorf("[StaticCredentials] ERROR: %s", err)
+		}
+		return creds, nil
 
-	return nil, fmt.Errorf("Failed to create credentials")
+	}
+	return nil, nil
 }
 
 func getS3Config(accessID, secretKey, credential, s3prefix, bucket, region, compress, endpoint, autoCreateBucket, logLevel, timeZone string) (*s3Config, error) {

--- a/vendor/github.com/aws/aws-sdk-go/aws/config.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/config.go
@@ -165,6 +165,13 @@ type Config struct {
 	// in the ARN, when an ARN is provided as an argument to a bucket parameter.
 	S3UseARNRegion *bool
 
+	// Set this to `true` to enable the SDK to unmarshal API response header maps to
+	// normalized lower case map keys.
+	//
+	// For example S3's X-Amz-Meta prefixed header will be unmarshaled to lower case
+	// Metadata member's map keys. The value of the header in the map is unaffected.
+	LowerCaseHeaderMaps *bool
+
 	// Set this to `true` to disable the EC2Metadata client from overriding the
 	// default http.Client's Timeout. This is helpful if you do not want the
 	// EC2Metadata client to create a new http.Client. This options is only

--- a/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
@@ -161,7 +161,7 @@ func handleSendError(r *request.Request, err error) {
 	}
 	// Catch all request errors, and let the default retrier determine
 	// if the error is retryable.
-	r.Error = awserr.New("RequestError", "send request failed", err)
+	r.Error = awserr.New(request.ErrCodeRequestError, "send request failed", err)
 
 	// Override the error with a context canceled error, if that was canceled.
 	ctx := r.Context()

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.5.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.5.go
@@ -1,12 +1,12 @@
 // +build !go1.7
 
-package aws
+package credentials
 
 import (
 	"github.com/aws/aws-sdk-go/internal/context"
 )
 
-// BackgroundContext returns a context that will never be canceled, has no
+// backgroundContext returns a context that will never be canceled, has no
 // values, and no deadline. This context is used by the SDK to provide
 // backwards compatibility with non-context API operations and functionality.
 //
@@ -17,6 +17,6 @@ import (
 // The context returned will be the value returned by context.Background()
 //
 // See https://golang.org/pkg/context for more information on Contexts.
-func BackgroundContext() Context {
+func backgroundContext() Context {
 	return context.BackgroundCtx
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.7.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.7.go
@@ -1,12 +1,10 @@
-// +build !go1.7
+// +build go1.7
 
-package aws
+package credentials
 
-import (
-	"github.com/aws/aws-sdk-go/internal/context"
-)
+import "context"
 
-// BackgroundContext returns a context that will never be canceled, has no
+// backgroundContext returns a context that will never be canceled, has no
 // values, and no deadline. This context is used by the SDK to provide
 // backwards compatibility with non-context API operations and functionality.
 //
@@ -17,6 +15,6 @@ import (
 // The context returned will be the value returned by context.Background()
 //
 // See https://golang.org/pkg/context for more information on Contexts.
-func BackgroundContext() Context {
-	return context.BackgroundCtx
+func backgroundContext() Context {
+	return context.Background()
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.5.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.5.go
@@ -1,0 +1,39 @@
+// +build !go1.9
+
+package credentials
+
+import "time"
+
+// Context is an copy of the Go v1.7 stdlib's context.Context interface.
+// It is represented as a SDK interface to enable you to use the "WithContext"
+// API methods with Go v1.6 and a Context type such as golang.org/x/net/context.
+//
+// This type, aws.Context, and context.Context are equivalent.
+//
+// See https://golang.org/pkg/context on how to use contexts.
+type Context interface {
+	// Deadline returns the time when work done on behalf of this context
+	// should be canceled. Deadline returns ok==false when no deadline is
+	// set. Successive calls to Deadline return the same results.
+	Deadline() (deadline time.Time, ok bool)
+
+	// Done returns a channel that's closed when work done on behalf of this
+	// context should be canceled. Done may return nil if this context can
+	// never be canceled. Successive calls to Done return the same value.
+	Done() <-chan struct{}
+
+	// Err returns a non-nil error value after Done is closed. Err returns
+	// Canceled if the context was canceled or DeadlineExceeded if the
+	// context's deadline passed. No other values for Err are defined.
+	// After Done is closed, successive calls to Err return the same value.
+	Err() error
+
+	// Value returns the value associated with this context for key, or nil
+	// if no value is associated with key. Successive calls to Value with
+	// the same key returns the same result.
+	//
+	// Use context values only for request-scoped data that transits
+	// processes and API boundaries, not for passing optional parameters to
+	// functions.
+	Value(key interface{}) interface{}
+}

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.9.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.9.go
@@ -1,0 +1,13 @@
+// +build go1.9
+
+package credentials
+
+import "context"
+
+// Context is an alias of the Go stdlib's context.Context interface.
+// It can be used within the SDK's API operation "WithContext" methods.
+//
+// This type, aws.Context, and context.Context are equivalent.
+//
+// See https://golang.org/pkg/context on how to use contexts.
+type Context = context.Context

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go
@@ -50,10 +50,11 @@ package credentials
 
 import (
 	"fmt"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/internal/sync/singleflight"
 )
 
 // AnonymousCredentials is an empty Credential object that can be used as
@@ -197,20 +198,62 @@ func (e *Expiry) ExpiresAt() time.Time {
 // first instance of the credentials Value. All calls to Get() after that
 // will return the cached credentials Value until IsExpired() returns true.
 type Credentials struct {
-	creds        Value
-	forceRefresh bool
-
-	m sync.RWMutex
+	creds atomic.Value
+	sf    singleflight.Group
 
 	provider Provider
 }
 
 // NewCredentials returns a pointer to a new Credentials with the provider set.
 func NewCredentials(provider Provider) *Credentials {
-	return &Credentials{
-		provider:     provider,
-		forceRefresh: true,
+	c := &Credentials{
+		provider: provider,
 	}
+	c.creds.Store(Value{})
+	return c
+}
+
+// GetWithContext returns the credentials value, or error if the credentials
+// Value failed to be retrieved. Will return early if the passed in context is
+// canceled.
+//
+// Will return the cached credentials Value if it has not expired. If the
+// credentials Value has expired the Provider's Retrieve() will be called
+// to refresh the credentials.
+//
+// If Credentials.Expire() was called the credentials Value will be force
+// expired, and the next call to Get() will cause them to be refreshed.
+//
+// Passed in Context is equivalent to aws.Context, and context.Context.
+func (c *Credentials) GetWithContext(ctx Context) (Value, error) {
+	if curCreds := c.creds.Load(); !c.isExpired(curCreds) {
+		return curCreds.(Value), nil
+	}
+
+	// Cannot pass context down to the actual retrieve, because the first
+	// context would cancel the whole group when there is not direct
+	// association of items in the group.
+	resCh := c.sf.DoChan("", c.singleRetrieve)
+	select {
+	case res := <-resCh:
+		return res.Val.(Value), res.Err
+	case <-ctx.Done():
+		return Value{}, awserr.New("RequestCanceled",
+			"request context canceled", ctx.Err())
+	}
+}
+
+func (c *Credentials) singleRetrieve() (interface{}, error) {
+	if curCreds := c.creds.Load(); !c.isExpired(curCreds) {
+		return curCreds.(Value), nil
+	}
+
+	creds, err := c.provider.Retrieve()
+	if err == nil {
+		c.creds.Store(creds)
+	}
+
+	return creds, err
 }
 
 // Get returns the credentials value, or error if the credentials Value failed
@@ -223,30 +266,7 @@ func NewCredentials(provider Provider) *Credentials {
 // If Credentials.Expire() was called the credentials Value will be force
 // expired, and the next call to Get() will cause them to be refreshed.
 func (c *Credentials) Get() (Value, error) {
-	// Check the cached credentials first with just the read lock.
-	c.m.RLock()
-	if !c.isExpired() {
-		creds := c.creds
-		c.m.RUnlock()
-		return creds, nil
-	}
-	c.m.RUnlock()
-
-	// Credentials are expired need to retrieve the credentials taking the full
-	// lock.
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	if c.isExpired() {
-		creds, err := c.provider.Retrieve()
-		if err != nil {
-			return Value{}, err
-		}
-		c.creds = creds
-		c.forceRefresh = false
-	}
-
-	return c.creds, nil
+	return c.GetWithContext(backgroundContext())
 }
 
 // Expire expires the credentials and forces them to be retrieved on the
@@ -255,10 +275,7 @@ func (c *Credentials) Get() (Value, error) {
 // This will override the Provider's expired state, and force Credentials
 // to call the Provider's Retrieve().
 func (c *Credentials) Expire() {
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	c.forceRefresh = true
+	c.creds.Store(Value{})
 }
 
 // IsExpired returns if the credentials are no longer valid, and need
@@ -267,31 +284,25 @@ func (c *Credentials) Expire() {
 // If the Credentials were forced to be expired with Expire() this will
 // reflect that override.
 func (c *Credentials) IsExpired() bool {
-	c.m.RLock()
-	defer c.m.RUnlock()
-
-	return c.isExpired()
+	return c.isExpired(c.creds.Load())
 }
 
 // isExpired helper method wrapping the definition of expired credentials.
-func (c *Credentials) isExpired() bool {
-	return c.forceRefresh || c.provider.IsExpired()
+func (c *Credentials) isExpired(creds interface{}) bool {
+	return creds == nil || creds.(Value) == Value{} || c.provider.IsExpired()
 }
 
 // ExpiresAt provides access to the functionality of the Expirer interface of
 // the underlying Provider, if it supports that interface.  Otherwise, it returns
 // an error.
 func (c *Credentials) ExpiresAt() (time.Time, error) {
-	c.m.RLock()
-	defer c.m.RUnlock()
-
 	expirer, ok := c.provider.(Expirer)
 	if !ok {
 		return time.Time{}, awserr.New("ProviderNotExpirer",
-			fmt.Sprintf("provider %s does not support ExpiresAt()", c.creds.ProviderName),
+			fmt.Sprintf("provider %s does not support ExpiresAt()", c.creds.Load().(Value).ProviderName),
 			nil)
 	}
-	if c.forceRefresh {
+	if c.creds.Load().(Value) == (Value{}) {
 		// set expiration time to the distant past
 		return time.Time{}, nil
 	}

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/static_provider.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/static_provider.go
@@ -19,7 +19,9 @@ type StaticProvider struct {
 }
 
 // NewStaticCredentials returns a pointer to a new Credentials object
-// wrapping a static credentials value provider.
+// wrapping a static credentials value provider. Token is only required
+// for temporary security credentials retrieved via STS, otherwise an empty
+// string can be passed for this parameter.
 func NewStaticCredentials(id, secret, token string) *Credentials {
 	return NewCredentials(&StaticProvider{Value: Value{
 		AccessKeyID:     id,

--- a/vendor/github.com/aws/aws-sdk-go/aws/csm/reporter.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/csm/reporter.go
@@ -89,7 +89,7 @@ func getMetricException(err awserr.Error) metricException {
 	code := err.Code()
 
 	switch code {
-	case "RequestError",
+	case request.ErrCodeRequestError,
 		request.ErrCodeSerialization,
 		request.CanceledErrorCode:
 		return sdkException{

--- a/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/service.go
@@ -80,8 +80,10 @@ func NewClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 			// use a shorter timeout than default because the metadata
 			// service is local if it is running, and to fail faster
 			// if not running on an ec2 instance.
-			Timeout: 5 * time.Second,
+			Timeout: 1 * time.Second,
 		}
+		// max number of retries on the client operation
+		cfg.MaxRetries = aws.Int(2)
 	}
 
 	svc := &EC2Metadata{

--- a/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/token_provider.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/token_provider.go
@@ -62,7 +62,7 @@ func (t *tokenProvider) fetchTokenHandler(r *request.Request) {
 
 			// Check if request timed out while waiting for response
 			if e, ok := requestFailureError.OrigErr().(awserr.Error); ok {
-				if e.Code() == "RequestError" {
+				if e.Code() == request.ErrCodeRequestError {
 					atomic.StoreUint32(&t.disabled, 1)
 				}
 			}

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -169,6 +169,29 @@ var awsPartition = partition{
 				"us-east-1": endpoint{},
 			},
 		},
+		"access-analyzer": service{
+
+			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
+				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
+				"sa-east-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
 		"acm": service{
 
 			Endpoints: endpoints{
@@ -511,6 +534,7 @@ var awsPartition = partition{
 		"appmesh": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -518,9 +542,12 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -1026,8 +1053,29 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
+		"codestar-connections": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -1046,9 +1094,27 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "cognito-identity-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "cognito-identity-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "cognito-identity-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"us-east-1": endpoint{},
+				"us-east-2": endpoint{},
+				"us-west-2": endpoint{},
 			},
 		},
 		"cognito-idp": service{
@@ -1063,9 +1129,27 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "cognito-idp-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "cognito-idp-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "cognito-idp-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"us-east-1": endpoint{},
+				"us-east-2": endpoint{},
+				"us-west-2": endpoint{},
 			},
 		},
 		"cognito-sync": service{
@@ -1089,6 +1173,9 @@ var awsPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
@@ -1207,6 +1294,12 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"fips-ca-central-1": endpoint{
+					Hostname: "datasync-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
 				"fips-us-east-1": endpoint{
 					Hostname: "datasync-fips.us-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -1303,17 +1396,23 @@ var awsPartition = partition{
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-north-1":     endpoint{},
-				"eu-west-1":      endpoint{},
-				"eu-west-2":      endpoint{},
-				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"dms-fips": endpoint{
+					Hostname: "dms-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"eu-central-1": endpoint{},
+				"eu-north-1":   endpoint{},
+				"eu-west-1":    endpoint{},
+				"eu-west-2":    endpoint{},
+				"eu-west-3":    endpoint{},
+				"me-south-1":   endpoint{},
+				"sa-east-1":    endpoint{},
+				"us-east-1":    endpoint{},
+				"us-east-2":    endpoint{},
+				"us-west-1":    endpoint{},
+				"us-west-2":    endpoint{},
 			},
 		},
 		"docdb": service{
@@ -1414,6 +1513,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -1662,6 +1762,36 @@ var awsPartition = partition{
 				"eu-west-1":  endpoint{},
 				"eu-west-2":  endpoint{},
 				"eu-west-3":  endpoint{},
+				"fips-ca-central-1": endpoint{
+					Hostname: "elasticmapreduce-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				"fips-us-east-1": endpoint{
+					Hostname: "elasticmapreduce-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "elasticmapreduce-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "elasticmapreduce-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "elasticmapreduce-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
 				"me-south-1": endpoint{},
 				"sa-east-1":  endpoint{},
 				"us-east-1": endpoint{
@@ -1797,18 +1927,112 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-ap-northeast-1": endpoint{
+					Hostname: "fms-fips.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+				},
+				"fips-ap-northeast-2": endpoint{
+					Hostname: "fms-fips.ap-northeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-2",
+					},
+				},
+				"fips-ap-south-1": endpoint{
+					Hostname: "fms-fips.ap-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-south-1",
+					},
+				},
+				"fips-ap-southeast-1": endpoint{
+					Hostname: "fms-fips.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+				},
+				"fips-ap-southeast-2": endpoint{
+					Hostname: "fms-fips.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+				},
+				"fips-ca-central-1": endpoint{
+					Hostname: "fms-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				"fips-eu-central-1": endpoint{
+					Hostname: "fms-fips.eu-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-central-1",
+					},
+				},
+				"fips-eu-west-1": endpoint{
+					Hostname: "fms-fips.eu-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+				},
+				"fips-eu-west-2": endpoint{
+					Hostname: "fms-fips.eu-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
+					},
+				},
+				"fips-eu-west-3": endpoint{
+					Hostname: "fms-fips.eu-west-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
+					},
+				},
+				"fips-sa-east-1": endpoint{
+					Hostname: "fms-fips.sa-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "sa-east-1",
+					},
+				},
+				"fips-us-east-1": endpoint{
+					Hostname: "fms-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "fms-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "fms-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "fms-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"sa-east-1": endpoint{},
+				"us-east-1": endpoint{},
+				"us-east-2": endpoint{},
+				"us-west-1": endpoint{},
+				"us-west-2": endpoint{},
 			},
 		},
 		"forecast": service{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -1819,7 +2043,11 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -1878,12 +2106,42 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-ca-central-1": endpoint{
+					Hostname: "glacier-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				"fips-us-east-1": endpoint{
+					Hostname: "glacier-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "glacier-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "glacier-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "glacier-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"glue": service{
@@ -2159,6 +2417,7 @@ var awsPartition = partition{
 		"iotsecuredtunneling": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -2170,6 +2429,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -2207,6 +2467,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -2240,6 +2501,7 @@ var awsPartition = partition{
 		"kinesisanalytics": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -2251,6 +2513,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -2412,6 +2675,15 @@ var awsPartition = partition{
 				"us-east-1": endpoint{},
 			},
 		},
+		"managedblockchain": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-southeast-1": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+			},
+		},
 		"marketplacecommerceanalytics": service{
 
 			Endpoints: endpoints{
@@ -2421,6 +2693,7 @@ var awsPartition = partition{
 		"mediaconnect": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -2589,6 +2862,7 @@ var awsPartition = partition{
 		"mq": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -2624,11 +2898,12 @@ var awsPartition = partition{
 						Region: "us-west-2",
 					},
 				},
-				"sa-east-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-1": endpoint{},
-				"us-west-2": endpoint{},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"mturk-requester": service{
@@ -2702,6 +2977,12 @@ var awsPartition = partition{
 					Hostname: "rds.eu-west-2.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "eu-west-2",
+					},
+				},
+				"eu-west-3": endpoint{
+					Hostname: "rds.eu-west-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
 					},
 				},
 				"me-south-1": endpoint{
@@ -2839,11 +3120,18 @@ var awsPartition = partition{
 		"outposts": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -2890,6 +3178,7 @@ var awsPartition = partition{
 		"polly": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -2901,6 +3190,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -2996,6 +3286,7 @@ var awsPartition = partition{
 		"ram": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -3007,6 +3298,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -3162,6 +3454,7 @@ var awsPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -3634,6 +3927,7 @@ var awsPartition = partition{
 		"servicecatalog": service{
 
 			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -3645,6 +3939,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-1-fips": endpoint{
@@ -3738,12 +4033,36 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-us-east-1": endpoint{
+					Hostname: "sms-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "sms-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "sms-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "sms-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"snowball": service{
@@ -3759,11 +4078,101 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-ap-northeast-1": endpoint{
+					Hostname: "snowball-fips.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+				},
+				"fips-ap-northeast-2": endpoint{
+					Hostname: "snowball-fips.ap-northeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-2",
+					},
+				},
+				"fips-ap-south-1": endpoint{
+					Hostname: "snowball-fips.ap-south-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-south-1",
+					},
+				},
+				"fips-ap-southeast-1": endpoint{
+					Hostname: "snowball-fips.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+				},
+				"fips-ap-southeast-2": endpoint{
+					Hostname: "snowball-fips.ap-southeast-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-2",
+					},
+				},
+				"fips-ca-central-1": endpoint{
+					Hostname: "snowball-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				"fips-eu-central-1": endpoint{
+					Hostname: "snowball-fips.eu-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-central-1",
+					},
+				},
+				"fips-eu-west-1": endpoint{
+					Hostname: "snowball-fips.eu-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-1",
+					},
+				},
+				"fips-eu-west-2": endpoint{
+					Hostname: "snowball-fips.eu-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-2",
+					},
+				},
+				"fips-eu-west-3": endpoint{
+					Hostname: "snowball-fips.eu-west-3.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "eu-west-3",
+					},
+				},
+				"fips-sa-east-1": endpoint{
+					Hostname: "snowball-fips.sa-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "sa-east-1",
+					},
+				},
+				"fips-us-east-1": endpoint{
+					Hostname: "snowball-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "snowball-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "snowball-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "snowball-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"sa-east-1": endpoint{},
+				"us-east-1": endpoint{},
+				"us-east-2": endpoint{},
+				"us-west-1": endpoint{},
+				"us-west-2": endpoint{},
 			},
 		},
 		"sns": service{
@@ -4311,6 +4720,13 @@ var awscnPartition = partition{
 		},
 	},
 	Services: services{
+		"acm": service{
+
+			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
 		"api.ecr": service{
 
 			Endpoints: endpoints{
@@ -4344,10 +4760,29 @@ var awscnPartition = partition{
 				"cn-northwest-1": endpoint{},
 			},
 		},
+		"appsync": service{
+
+			Endpoints: endpoints{
+				"cn-north-1": endpoint{},
+			},
+		},
+		"athena": service{
+
+			Endpoints: endpoints{
+				"cn-northwest-1": endpoint{},
+			},
+		},
 		"autoscaling": service{
 			Defaults: endpoint{
 				Protocols: []string{"http", "https"},
 			},
+			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
+		"backup": service{
+
 			Endpoints: endpoints{
 				"cn-north-1":     endpoint{},
 				"cn-northwest-1": endpoint{},
@@ -4492,6 +4927,13 @@ var awscnPartition = partition{
 				"cn-northwest-1": endpoint{},
 			},
 		},
+		"elasticfilesystem": service{
+
+			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
 		"elasticloadbalancing": service{
 			Defaults: endpoint{
 				Protocols: []string{"https"},
@@ -4561,6 +5003,13 @@ var awscnPartition = partition{
 				"cn-north-1": endpoint{},
 			},
 		},
+		"health": service{
+
+			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
 		"iam": service{
 			PartitionEndpoint: "aws-cn-global",
 			IsRegionalized:    boxedFalse,
@@ -4580,6 +5029,13 @@ var awscnPartition = partition{
 					Service: "execute-api",
 				},
 			},
+			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
+		"iotsecuredtunneling": service{
+
 			Endpoints: endpoints{
 				"cn-north-1":     endpoint{},
 				"cn-northwest-1": endpoint{},
@@ -4638,6 +5094,17 @@ var awscnPartition = partition{
 			Endpoints: endpoints{
 				"cn-north-1":     endpoint{},
 				"cn-northwest-1": endpoint{},
+			},
+		},
+		"neptune": service{
+
+			Endpoints: endpoints{
+				"cn-northwest-1": endpoint{
+					Hostname: "rds.cn-northwest-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-northwest-1",
+					},
+				},
 			},
 		},
 		"polly": service{
@@ -4699,6 +5166,19 @@ var awscnPartition = partition{
 				"cn-northwest-1": endpoint{},
 			},
 		},
+		"serverlessrepo": service{
+			Defaults: endpoint{
+				Protocols: []string{"https"},
+			},
+			Endpoints: endpoints{
+				"cn-north-1": endpoint{
+					Protocols: []string{"https"},
+				},
+				"cn-northwest-1": endpoint{
+					Protocols: []string{"https"},
+				},
+			},
+		},
 		"sms": service{
 
 			Endpoints: endpoints{
@@ -4710,6 +5190,12 @@ var awscnPartition = partition{
 
 			Endpoints: endpoints{
 				"cn-north-1": endpoint{},
+				"fips-cn-north-1": endpoint{
+					Hostname: "snowball-fips.cn-north-1.amazonaws.com.cn",
+					CredentialScope: credentialScope{
+						Region: "cn-north-1",
+					},
+				},
 			},
 		},
 		"sns": service{
@@ -4748,7 +5234,8 @@ var awscnPartition = partition{
 		"storagegateway": service{
 
 			Endpoints: endpoints{
-				"cn-north-1": endpoint{},
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
 			},
 		},
 		"streams.dynamodb": service{
@@ -4860,6 +5347,13 @@ var awsusgovPartition = partition{
 		},
 	},
 	Services: services{
+		"access-analyzer": service{
+
+			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
+				"us-gov-west-1": endpoint{},
+			},
+		},
 		"acm": service{
 
 			Endpoints: endpoints{
@@ -4939,6 +5433,18 @@ var awsusgovPartition = partition{
 		"athena": service{
 
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "athena-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "athena-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
@@ -4950,6 +5456,22 @@ var awsusgovPartition = partition{
 				"us-gov-west-1": endpoint{
 					Protocols: []string{"http", "https"},
 				},
+			},
+		},
+		"autoscaling-plans": service{
+			Defaults: endpoint{
+				Protocols: []string{"http", "https"},
+			},
+			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
+				"us-gov-west-1": endpoint{},
+			},
+		},
+		"batch": service{
+
+			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
+				"us-gov-west-1": endpoint{},
 			},
 		},
 		"clouddirectory": service{
@@ -5030,6 +5552,12 @@ var awsusgovPartition = partition{
 				"us-gov-west-1": endpoint{},
 			},
 		},
+		"comprehendmedical": service{
+
+			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
+			},
+		},
 		"config": service{
 
 			Endpoints: endpoints{
@@ -5040,6 +5568,12 @@ var awsusgovPartition = partition{
 		"datasync": service{
 
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "datasync-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
 				"fips-us-gov-west-1": endpoint{
 					Hostname: "datasync-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -5060,6 +5594,12 @@ var awsusgovPartition = partition{
 		"dms": service{
 
 			Endpoints: endpoints{
+				"dms-fips": endpoint{
+					Hostname: "dms.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
@@ -5138,6 +5678,7 @@ var awsusgovPartition = partition{
 		"elasticfilesystem": service{
 
 			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
 		},
@@ -5189,9 +5730,18 @@ var awsusgovPartition = partition{
 		"glacier": service{
 
 			Endpoints: endpoints{
-				"us-gov-east-1": endpoint{},
+				"us-gov-east-1": endpoint{
+					Hostname: "glacier.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
 				"us-gov-west-1": endpoint{
+					Hostname:  "glacier.us-gov-west-1.amazonaws.com",
 					Protocols: []string{"http", "https"},
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
 				},
 			},
 		},
@@ -5252,6 +5802,12 @@ var awsusgovPartition = partition{
 					Service: "execute-api",
 				},
 			},
+			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
+			},
+		},
+		"iotsecuredtunneling": service{
+
 			Endpoints: endpoints{
 				"us-gov-west-1": endpoint{},
 			},
@@ -5533,6 +6089,18 @@ var awsusgovPartition = partition{
 		"sms": service{
 
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "sms-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "sms-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
@@ -5540,6 +6108,18 @@ var awsusgovPartition = partition{
 		"snowball": service{
 
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "snowball-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "snowball-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
@@ -5580,6 +6160,7 @@ var awsusgovPartition = partition{
 		"storagegateway": service{
 
 			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
 		},
@@ -5613,6 +6194,18 @@ var awsusgovPartition = partition{
 				"us-gov-west-1": endpoint{},
 			},
 		},
+		"support": service{
+			PartitionEndpoint: "aws-us-gov-global",
+
+			Endpoints: endpoints{
+				"aws-us-gov-global": endpoint{
+					Hostname: "support.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+			},
+		},
 		"swf": service{
 
 			Endpoints: endpoints{
@@ -5632,6 +6225,7 @@ var awsusgovPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
 		},
@@ -5658,6 +6252,13 @@ var awsusgovPartition = partition{
 		"workspaces": service{
 
 			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
+			},
+		},
+		"xray": service{
+
+			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
 		},
@@ -5715,7 +6316,6 @@ var awsisoPartition = partition{
 		},
 		"application-autoscaling": service{
 			Defaults: endpoint{
-				Hostname:  "autoscaling.us-iso-east-1.c2s.ic.gov",
 				Protocols: []string{"http", "https"},
 			},
 			Endpoints: endpoints{
@@ -5769,6 +6369,12 @@ var awsisoPartition = partition{
 		"dms": service{
 
 			Endpoints: endpoints{
+				"dms-fips": endpoint{
+					Hostname: "dms.us-iso-east-1.c2s.ic.gov",
+					CredentialScope: credentialScope{
+						Region: "us-iso-east-1",
+					},
+				},
 				"us-iso-east-1": endpoint{},
 			},
 		},
@@ -6044,7 +6650,6 @@ var awsisobPartition = partition{
 	Services: services{
 		"application-autoscaling": service{
 			Defaults: endpoint{
-				Hostname:  "autoscaling.us-isob-east-1.sc2s.sgov.gov",
 				Protocols: []string{"http", "https"},
 			},
 			Endpoints: endpoints{
@@ -6086,6 +6691,12 @@ var awsisobPartition = partition{
 		"dms": service{
 
 			Endpoints: endpoints{
+				"dms-fips": endpoint{
+					Hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
+					CredentialScope: credentialScope{
+						Region: "us-isob-east-1",
+					},
+				},
 				"us-isob-east-1": endpoint{},
 			},
 		},
@@ -6185,6 +6796,12 @@ var awsisobPartition = partition{
 				"us-isob-east-1": endpoint{},
 			},
 		},
+		"license-manager": service{
+
+			Endpoints: endpoints{
+				"us-isob-east-1": endpoint{},
+			},
+		},
 		"logs": service{
 
 			Endpoints: endpoints{
@@ -6237,6 +6854,12 @@ var awsisobPartition = partition{
 				SSLCommonName: "{region}.queue.{dnsSuffix}",
 				Protocols:     []string{"http", "https"},
 			},
+			Endpoints: endpoints{
+				"us-isob-east-1": endpoint{},
+			},
+		},
+		"ssm": service{
+
 			Endpoints: endpoints{
 				"us-isob-east-1": endpoint{},
 			},

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/handlers.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/handlers.go
@@ -10,6 +10,7 @@ import (
 type Handlers struct {
 	Validate         HandlerList
 	Build            HandlerList
+	BuildStream      HandlerList
 	Sign             HandlerList
 	Send             HandlerList
 	ValidateResponse HandlerList
@@ -28,6 +29,7 @@ func (h *Handlers) Copy() Handlers {
 	return Handlers{
 		Validate:         h.Validate.copy(),
 		Build:            h.Build.copy(),
+		BuildStream:      h.BuildStream.copy(),
 		Sign:             h.Sign.copy(),
 		Send:             h.Send.copy(),
 		ValidateResponse: h.ValidateResponse.copy(),
@@ -46,6 +48,7 @@ func (h *Handlers) Copy() Handlers {
 func (h *Handlers) Clear() {
 	h.Validate.Clear()
 	h.Build.Clear()
+	h.BuildStream.Clear()
 	h.Send.Clear()
 	h.Sign.Clear()
 	h.Unmarshal.Clear()
@@ -65,6 +68,9 @@ func (h *Handlers) IsEmpty() bool {
 		return false
 	}
 	if h.Build.Len() != 0 {
+		return false
+	}
+	if h.BuildStream.Len() != 0 {
 		return false
 	}
 	if h.Send.Len() != 0 {
@@ -318,5 +324,20 @@ func MakeAddToUserAgentHandler(name, version string, extra ...string) func(*Requ
 func MakeAddToUserAgentFreeFormHandler(s string) func(*Request) {
 	return func(r *Request) {
 		AddToUserAgent(r, s)
+	}
+}
+
+// WithSetRequestHeaders updates the operation request's HTTP header to contain
+// the header key value pairs provided. If the header key already exists in the
+// request's HTTP header set, the existing value(s) will be replaced.
+func WithSetRequestHeaders(h map[string]string) Option {
+	return withRequestHeader(h).SetRequestHeaders
+}
+
+type withRequestHeader map[string]string
+
+func (h withRequestHeader) SetRequestHeaders(r *Request) {
+	for k, v := range h {
+		r.HTTPRequest.Header[k] = []string{v}
 	}
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
@@ -36,6 +36,10 @@ const (
 	// API request that was canceled. Requests given a aws.Context may
 	// return this error when canceled.
 	CanceledErrorCode = "RequestCanceled"
+
+	// ErrCodeRequestError is an error preventing the SDK from continuing to
+	// process the request.
+	ErrCodeRequestError = "RequestError"
 )
 
 // A Request is the service request to be made.
@@ -51,6 +55,7 @@ type Request struct {
 	HTTPRequest            *http.Request
 	HTTPResponse           *http.Response
 	Body                   io.ReadSeeker
+	streamingBody          io.ReadCloser
 	BodyStart              int64 // offset from beginning of Body that the request body starts
 	Params                 interface{}
 	Error                  error
@@ -129,8 +134,6 @@ func New(cfg aws.Config, clientInfo metadata.ClientInfo, handlers Handlers,
 		httpReq.URL = &url.URL{}
 		err = awserr.New("InvalidEndpointURL", "invalid endpoint uri", err)
 	}
-
-	SanitizeHostForHeader(httpReq)
 
 	r := &Request{
 		Config:     cfg,
@@ -295,6 +298,13 @@ func (r *Request) SetReaderBody(reader io.ReadSeeker) {
 	r.ResetBody()
 }
 
+// SetStreamingBody set the reader to be used for the request that will stream
+// bytes to the server. Request's Body must not be set to any reader.
+func (r *Request) SetStreamingBody(reader io.ReadCloser) {
+	r.streamingBody = reader
+	r.SetReaderBody(aws.ReadSeekCloser(reader))
+}
+
 // Presign returns the request's signed URL. Error will be returned
 // if the signing fails. The expire parameter is only used for presigned Amazon
 // S3 API requests. All other AWS services will use a fixed expiration
@@ -414,11 +424,17 @@ func (r *Request) Sign() error {
 		return r.Error
 	}
 
+	SanitizeHostForHeader(r.HTTPRequest)
+
 	r.Handlers.Sign.Run(r)
 	return r.Error
 }
 
 func (r *Request) getNextRequestBody() (body io.ReadCloser, err error) {
+	if r.streamingBody != nil {
+		return r.streamingBody, nil
+	}
+
 	if r.safeBody != nil {
 		r.safeBody.Close()
 	}
@@ -621,6 +637,10 @@ func SanitizeHostForHeader(r *http.Request) {
 func getHost(r *http.Request) string {
 	if r.Host != "" {
 		return r.Host
+	}
+
+	if r.URL == nil {
+		return ""
 	}
 
 	return r.URL.Host

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
@@ -75,7 +75,7 @@ func (d noOpRetryer) RetryRules(_ *Request) time.Duration {
 // retryableCodes is a collection of service response codes which are retry-able
 // without any further action.
 var retryableCodes = map[string]struct{}{
-	"RequestError":            {},
+	ErrCodeRequestError:       {},
 	"RequestTimeout":          {},
 	ErrCodeResponseTimeout:    {},
 	"RequestTimeoutException": {}, // Glacier's flavor of RequestTimeout
@@ -92,6 +92,7 @@ var throttleCodes = map[string]struct{}{
 	"TooManyRequestsException":               {}, // Lambda functions
 	"PriorRequestNotComplete":                {}, // Route53
 	"TransactionInProgressException":         {},
+	"EC2ThrottledException":                  {}, // EC2
 }
 
 // credsExpiredCodes is a collection of error codes which signify the credentials
@@ -178,7 +179,7 @@ func shouldRetryError(origErr error) bool {
 		var shouldRetry bool
 		if origErr != nil {
 			shouldRetry = shouldRetryError(origErr)
-			if err.Code() == "RequestError" && !shouldRetry {
+			if err.Code() == ErrCodeRequestError && !shouldRetry {
 				return false
 			}
 		}

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/credentials.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/credentials.go
@@ -3,6 +3,7 @@ package session
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -206,7 +207,14 @@ func credsFromAssumeRole(cfg aws.Config,
 		sharedCfg.RoleARN,
 		func(opt *stscreds.AssumeRoleProvider) {
 			opt.RoleSessionName = sharedCfg.RoleSessionName
-			opt.Duration = sessOpts.AssumeRoleDuration
+
+			if sessOpts.AssumeRoleDuration == 0 &&
+				sharedCfg.AssumeRoleDuration != nil &&
+				*sharedCfg.AssumeRoleDuration/time.Minute > 15 {
+				opt.Duration = *sharedCfg.AssumeRoleDuration
+			} else if sessOpts.AssumeRoleDuration != 0 {
+				opt.Duration = sessOpts.AssumeRoleDuration
+			}
 
 			// Assume role with external ID
 			if len(sharedCfg.ExternalID) > 0 {

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
@@ -642,10 +642,16 @@ func (s *Session) ClientConfig(service string, cfgs ...*aws.Config) client.Confi
 
 	region := aws.StringValue(s.Config.Region)
 	resolved, err := s.resolveEndpoint(service, region, s.Config)
-	if err != nil && s.Config.Logger != nil {
-		s.Config.Logger.Log(fmt.Sprintf(
-			"ERROR: unable to resolve endpoint for service %q, region %q, err: %v",
-			service, region, err))
+	if err != nil {
+		s.Handlers.Validate.PushBack(func(r *request.Request) {
+			if len(r.ClientInfo.Endpoint) != 0 {
+				// Error occurred while resolving endpoint, but the request
+				// being invoked has had an endpoint specified after the client
+				// was created.
+				return
+			}
+			r.Error = err
+		})
 	}
 
 	return client.Config{

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/header_rules.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/header_rules.go
@@ -1,8 +1,7 @@
 package v4
 
 import (
-	"net/http"
-	"strings"
+	"github.com/aws/aws-sdk-go/internal/strings"
 )
 
 // validator houses a set of rule needed for validation of a
@@ -61,7 +60,7 @@ type patterns []string
 // been found
 func (p patterns) IsValid(value string) bool {
 	for _, pattern := range p {
-		if strings.HasPrefix(http.CanonicalHeaderKey(value), pattern) {
+		if strings.HasPrefixFold(value, pattern) {
 			return true
 		}
 	}

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.5.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.5.go
@@ -1,0 +1,13 @@
+// +build !go1.7
+
+package v4
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func requestContext(r *http.Request) aws.Context {
+	return aws.BackgroundContext()
+}

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.7.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.7.go
@@ -1,0 +1,13 @@
+// +build go1.7
+
+package v4
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func requestContext(r *http.Request) aws.Context {
+	return r.Context()
+}

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/stream.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/stream.go
@@ -1,0 +1,63 @@
+package v4
+
+import (
+	"encoding/hex"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+type credentialValueProvider interface {
+	Get() (credentials.Value, error)
+}
+
+// StreamSigner implements signing of event stream encoded payloads
+type StreamSigner struct {
+	region  string
+	service string
+
+	credentials credentialValueProvider
+
+	prevSig []byte
+}
+
+// NewStreamSigner creates a SigV4 signer used to sign Event Stream encoded messages
+func NewStreamSigner(region, service string, seedSignature []byte, credentials *credentials.Credentials) *StreamSigner {
+	return &StreamSigner{
+		region:      region,
+		service:     service,
+		credentials: credentials,
+		prevSig:     seedSignature,
+	}
+}
+
+// GetSignature takes an event stream encoded headers and payload and returns a signature
+func (s *StreamSigner) GetSignature(headers, payload []byte, date time.Time) ([]byte, error) {
+	credValue, err := s.credentials.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	sigKey := deriveSigningKey(s.region, s.service, credValue.SecretAccessKey, date)
+
+	keyPath := buildSigningScope(s.region, s.service, date)
+
+	stringToSign := buildEventStreamStringToSign(headers, payload, s.prevSig, keyPath, date)
+
+	signature := hmacSHA256(sigKey, []byte(stringToSign))
+	s.prevSig = signature
+
+	return signature, nil
+}
+
+func buildEventStreamStringToSign(headers, payload, prevSig []byte, scope string, date time.Time) string {
+	return strings.Join([]string{
+		"AWS4-HMAC-SHA256-PAYLOAD",
+		formatTime(date),
+		scope,
+		hex.EncodeToString(prevSig),
+		hex.EncodeToString(hashSHA256(headers)),
+		hex.EncodeToString(hashSHA256(payload)),
+	}, "\n")
+}

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
@@ -76,9 +76,14 @@ import (
 )
 
 const (
+	authorizationHeader     = "Authorization"
+	authHeaderSignatureElem = "Signature="
+	signatureQueryKey       = "X-Amz-Signature"
+
 	authHeaderPrefix = "AWS4-HMAC-SHA256"
 	timeFormat       = "20060102T150405Z"
 	shortTimeFormat  = "20060102"
+	awsV4Request     = "aws4_request"
 
 	// emptyStringSHA256 is a SHA256 of an empty string
 	emptyStringSHA256 = `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
@@ -87,9 +92,9 @@ const (
 var ignoredHeaders = rules{
 	blacklist{
 		mapRule{
-			"Authorization":   struct{}{},
-			"User-Agent":      struct{}{},
-			"X-Amzn-Trace-Id": struct{}{},
+			authorizationHeader: struct{}{},
+			"User-Agent":        struct{}{},
+			"X-Amzn-Trace-Id":   struct{}{},
 		},
 	},
 }
@@ -229,11 +234,9 @@ type signingCtx struct {
 
 	DisableURIPathEscaping bool
 
-	credValues         credentials.Value
-	isPresign          bool
-	formattedTime      string
-	formattedShortTime string
-	unsignedPayload    bool
+	credValues      credentials.Value
+	isPresign       bool
+	unsignedPayload bool
 
 	bodyDigest       string
 	signedHeaders    string
@@ -337,7 +340,7 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 	}
 
 	var err error
-	ctx.credValues, err = v4.Credentials.Get()
+	ctx.credValues, err = v4.Credentials.GetWithContext(requestContext(r))
 	if err != nil {
 		return http.Header{}, err
 	}
@@ -532,39 +535,56 @@ func (ctx *signingCtx) build(disableHeaderHoisting bool) error {
 	ctx.buildSignature()       // depends on string to sign
 
 	if ctx.isPresign {
-		ctx.Request.URL.RawQuery += "&X-Amz-Signature=" + ctx.signature
+		ctx.Request.URL.RawQuery += "&" + signatureQueryKey + "=" + ctx.signature
 	} else {
 		parts := []string{
 			authHeaderPrefix + " Credential=" + ctx.credValues.AccessKeyID + "/" + ctx.credentialString,
 			"SignedHeaders=" + ctx.signedHeaders,
-			"Signature=" + ctx.signature,
+			authHeaderSignatureElem + ctx.signature,
 		}
-		ctx.Request.Header.Set("Authorization", strings.Join(parts, ", "))
+		ctx.Request.Header.Set(authorizationHeader, strings.Join(parts, ", "))
 	}
 
 	return nil
 }
 
-func (ctx *signingCtx) buildTime() {
-	ctx.formattedTime = ctx.Time.UTC().Format(timeFormat)
-	ctx.formattedShortTime = ctx.Time.UTC().Format(shortTimeFormat)
+// GetSignedRequestSignature attempts to extract the signature of the request.
+// Returning an error if the request is unsigned, or unable to extract the
+// signature.
+func GetSignedRequestSignature(r *http.Request) ([]byte, error) {
 
+	if auth := r.Header.Get(authorizationHeader); len(auth) != 0 {
+		ps := strings.Split(auth, ", ")
+		for _, p := range ps {
+			if idx := strings.Index(p, authHeaderSignatureElem); idx >= 0 {
+				sig := p[len(authHeaderSignatureElem):]
+				if len(sig) == 0 {
+					return nil, fmt.Errorf("invalid request signature authorization header")
+				}
+				return hex.DecodeString(sig)
+			}
+		}
+	}
+
+	if sig := r.URL.Query().Get("X-Amz-Signature"); len(sig) != 0 {
+		return hex.DecodeString(sig)
+	}
+
+	return nil, fmt.Errorf("request not signed")
+}
+
+func (ctx *signingCtx) buildTime() {
 	if ctx.isPresign {
 		duration := int64(ctx.ExpireTime / time.Second)
-		ctx.Query.Set("X-Amz-Date", ctx.formattedTime)
+		ctx.Query.Set("X-Amz-Date", formatTime(ctx.Time))
 		ctx.Query.Set("X-Amz-Expires", strconv.FormatInt(duration, 10))
 	} else {
-		ctx.Request.Header.Set("X-Amz-Date", ctx.formattedTime)
+		ctx.Request.Header.Set("X-Amz-Date", formatTime(ctx.Time))
 	}
 }
 
 func (ctx *signingCtx) buildCredentialString() {
-	ctx.credentialString = strings.Join([]string{
-		ctx.formattedShortTime,
-		ctx.Region,
-		ctx.ServiceName,
-		"aws4_request",
-	}, "/")
+	ctx.credentialString = buildSigningScope(ctx.Region, ctx.ServiceName, ctx.Time)
 
 	if ctx.isPresign {
 		ctx.Query.Set("X-Amz-Credential", ctx.credValues.AccessKeyID+"/"+ctx.credentialString)
@@ -588,8 +608,7 @@ func (ctx *signingCtx) buildCanonicalHeaders(r rule, header http.Header) {
 	var headers []string
 	headers = append(headers, "host")
 	for k, v := range header {
-		canonicalKey := http.CanonicalHeaderKey(k)
-		if !r.IsValid(canonicalKey) {
+		if !r.IsValid(k) {
 			continue // ignored header
 		}
 		if ctx.SignedHeaderVals == nil {
@@ -653,19 +672,15 @@ func (ctx *signingCtx) buildCanonicalString() {
 func (ctx *signingCtx) buildStringToSign() {
 	ctx.stringToSign = strings.Join([]string{
 		authHeaderPrefix,
-		ctx.formattedTime,
+		formatTime(ctx.Time),
 		ctx.credentialString,
-		hex.EncodeToString(makeSha256([]byte(ctx.canonicalString))),
+		hex.EncodeToString(hashSHA256([]byte(ctx.canonicalString))),
 	}, "\n")
 }
 
 func (ctx *signingCtx) buildSignature() {
-	secret := ctx.credValues.SecretAccessKey
-	date := makeHmac([]byte("AWS4"+secret), []byte(ctx.formattedShortTime))
-	region := makeHmac(date, []byte(ctx.Region))
-	service := makeHmac(region, []byte(ctx.ServiceName))
-	credentials := makeHmac(service, []byte("aws4_request"))
-	signature := makeHmac(credentials, []byte(ctx.stringToSign))
+	creds := deriveSigningKey(ctx.Region, ctx.ServiceName, ctx.credValues.SecretAccessKey, ctx.Time)
+	signature := hmacSHA256(creds, []byte(ctx.stringToSign))
 	ctx.signature = hex.EncodeToString(signature)
 }
 
@@ -726,13 +741,13 @@ func (ctx *signingCtx) removePresign() {
 	ctx.Query.Del("X-Amz-SignedHeaders")
 }
 
-func makeHmac(key []byte, data []byte) []byte {
+func hmacSHA256(key []byte, data []byte) []byte {
 	hash := hmac.New(sha256.New, key)
 	hash.Write(data)
 	return hash.Sum(nil)
 }
 
-func makeSha256(data []byte) []byte {
+func hashSHA256(data []byte) []byte {
 	hash := sha256.New()
 	hash.Write(data)
 	return hash.Sum(nil)
@@ -803,4 +818,29 @@ func stripExcessSpaces(vals []string) {
 
 		vals[i] = string(buf[:m])
 	}
+}
+
+func buildSigningScope(region, service string, dt time.Time) string {
+	return strings.Join([]string{
+		formatShortTime(dt),
+		region,
+		service,
+		awsV4Request,
+	}, "/")
+}
+
+func deriveSigningKey(region, service, secretKey string, dt time.Time) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secretKey), []byte(formatShortTime(dt)))
+	kRegion := hmacSHA256(kDate, []byte(region))
+	kService := hmacSHA256(kRegion, []byte(service))
+	signingKey := hmacSHA256(kService, []byte(awsV4Request))
+	return signingKey
+}
+
+func formatShortTime(dt time.Time) string {
+	return dt.UTC().Format(shortTimeFormat)
+}
+
+func formatTime(dt time.Time) string {
+	return dt.UTC().Format(timeFormat)
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.26.8"
+const SDKVersion = "1.29.31"

--- a/vendor/github.com/aws/aws-sdk-go/internal/context/background_go1.5.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/context/background_go1.5.go
@@ -1,0 +1,40 @@
+// +build !go1.7
+
+package context
+
+import "time"
+
+// An emptyCtx is a copy of the Go 1.7 context.emptyCtx type. This is copied to
+// provide a 1.6 and 1.5 safe version of context that is compatible with Go
+// 1.7's Context.
+//
+// An emptyCtx is never canceled, has no values, and has no deadline. It is not
+// struct{}, since vars of this type must have distinct addresses.
+type emptyCtx int
+
+func (*emptyCtx) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (*emptyCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (*emptyCtx) Err() error {
+	return nil
+}
+
+func (*emptyCtx) Value(key interface{}) interface{} {
+	return nil
+}
+
+func (e *emptyCtx) String() string {
+	switch e {
+	case BackgroundCtx:
+		return "aws.BackgroundContext"
+	}
+	return "unknown empty Context"
+}
+
+// BackgroundCtx is the common base context.
+var BackgroundCtx = new(emptyCtx)

--- a/vendor/github.com/aws/aws-sdk-go/internal/strings/strings.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/strings/strings.go
@@ -1,0 +1,11 @@
+package strings
+
+import (
+	"strings"
+)
+
+// HasPrefixFold tests whether the string s begins with prefix, interpreted as UTF-8 strings,
+// under Unicode case-folding.
+func HasPrefixFold(s, prefix string) bool {
+	return len(s) >= len(prefix) && strings.EqualFold(s[0:len(prefix)], prefix)
+}

--- a/vendor/github.com/aws/aws-sdk-go/internal/sync/singleflight/LICENSE
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sync/singleflight/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/aws/aws-sdk-go/internal/sync/singleflight/singleflight.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sync/singleflight/singleflight.go
@@ -1,0 +1,120 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight
+
+import "sync"
+
+// call is an in-flight or completed singleflight.Do call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// forgotten indicates whether Forget was called with this call's key
+	// while the call was still in flight.
+	forgotten bool
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (v interface{}, err error, shared bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+		return c.val, c.err, true
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.err, c.dups > 0
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+func (g *Group) DoChan(key string, fn func() (interface{}, error)) <-chan Result {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call{chans: []chan<- Result{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	g.mu.Lock()
+	if !c.forgotten {
+		delete(g.m, key)
+	}
+	for _, ch := range c.chans {
+		ch <- Result{c.val, c.err, c.dups > 0}
+	}
+	g.mu.Unlock()
+}
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group) Forget(key string) {
+	g.mu.Lock()
+	if c, ok := g.m[key]; ok {
+		c.forgotten = true
+	}
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/debug.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/debug.go
@@ -101,7 +101,7 @@ func (hs *decodedHeaders) UnmarshalJSON(b []byte) error {
 		}
 		headers.Set(h.Name, value)
 	}
-	(*hs) = decodedHeaders(headers)
+	*hs = decodedHeaders(headers)
 
 	return nil
 }

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/encode.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/encode.go
@@ -3,61 +3,107 @@ package eventstream
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"hash"
 	"hash/crc32"
 	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 // Encoder provides EventStream message encoding.
 type Encoder struct {
-	w io.Writer
+	w      io.Writer
+	logger aws.Logger
 
 	headersBuf *bytes.Buffer
 }
 
 // NewEncoder initializes and returns an Encoder to encode Event Stream
 // messages to an io.Writer.
-func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{
+func NewEncoder(w io.Writer, opts ...func(*Encoder)) *Encoder {
+	e := &Encoder{
 		w:          w,
 		headersBuf: bytes.NewBuffer(nil),
+	}
+
+	for _, opt := range opts {
+		opt(e)
+	}
+
+	return e
+}
+
+// EncodeWithLogger adds a logger to be used by the encode when decoding
+// stream events.
+func EncodeWithLogger(logger aws.Logger) func(*Encoder) {
+	return func(d *Encoder) {
+		d.logger = logger
 	}
 }
 
 // Encode encodes a single EventStream message to the io.Writer the Encoder
 // was created with. An error is returned if writing the message fails.
-func (e *Encoder) Encode(msg Message) error {
+func (e *Encoder) Encode(msg Message) (err error) {
 	e.headersBuf.Reset()
 
-	err := encodeHeaders(e.headersBuf, msg.Headers)
-	if err != nil {
+	writer := e.w
+	if e.logger != nil {
+		encodeMsgBuf := bytes.NewBuffer(nil)
+		writer = io.MultiWriter(writer, encodeMsgBuf)
+		defer func() {
+			logMessageEncode(e.logger, encodeMsgBuf, msg, err)
+		}()
+	}
+
+	if err = EncodeHeaders(e.headersBuf, msg.Headers); err != nil {
 		return err
 	}
 
 	crc := crc32.New(crc32IEEETable)
-	hashWriter := io.MultiWriter(e.w, crc)
+	hashWriter := io.MultiWriter(writer, crc)
 
 	headersLen := uint32(e.headersBuf.Len())
 	payloadLen := uint32(len(msg.Payload))
 
-	if err := encodePrelude(hashWriter, crc, headersLen, payloadLen); err != nil {
+	if err = encodePrelude(hashWriter, crc, headersLen, payloadLen); err != nil {
 		return err
 	}
 
 	if headersLen > 0 {
-		if _, err := io.Copy(hashWriter, e.headersBuf); err != nil {
+		if _, err = io.Copy(hashWriter, e.headersBuf); err != nil {
 			return err
 		}
 	}
 
 	if payloadLen > 0 {
-		if _, err := hashWriter.Write(msg.Payload); err != nil {
+		if _, err = hashWriter.Write(msg.Payload); err != nil {
 			return err
 		}
 	}
 
 	msgCRC := crc.Sum32()
-	return binary.Write(e.w, binary.BigEndian, msgCRC)
+	return binary.Write(writer, binary.BigEndian, msgCRC)
+}
+
+func logMessageEncode(logger aws.Logger, msgBuf *bytes.Buffer, msg Message, encodeErr error) {
+	w := bytes.NewBuffer(nil)
+	defer func() { logger.Log(w.String()) }()
+
+	fmt.Fprintf(w, "Message to encode:\n")
+	encoder := json.NewEncoder(w)
+	if err := encoder.Encode(msg); err != nil {
+		fmt.Fprintf(w, "Failed to get encoded message, %v\n", err)
+	}
+
+	if encodeErr != nil {
+		fmt.Fprintf(w, "Encode error: %v\n", encodeErr)
+		return
+	}
+
+	fmt.Fprintf(w, "Raw message:\n%s\n", hex.Dump(msgBuf.Bytes()))
 }
 
 func encodePrelude(w io.Writer, crc hash.Hash32, headersLen, payloadLen uint32) error {
@@ -86,7 +132,9 @@ func encodePrelude(w io.Writer, crc hash.Hash32, headersLen, payloadLen uint32) 
 	return nil
 }
 
-func encodeHeaders(w io.Writer, headers Headers) error {
+// EncodeHeaders writes the header values to the writer encoded in the event
+// stream format. Returns an error if a header fails to encode.
+func EncodeHeaders(w io.Writer, headers Headers) error {
 	for _, h := range headers {
 		hn := headerName{
 			Len: uint8(len(h.Name)),

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/error.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/error.go
@@ -1,6 +1,9 @@
 package eventstreamapi
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 type messageError struct {
 	code string
@@ -21,4 +24,54 @@ func (e messageError) Error() string {
 
 func (e messageError) OrigErr() error {
 	return nil
+}
+
+// OnceError wraps the behavior of recording an error
+// once and signal on a channel when this has occurred.
+// Signaling is done by closing of the channel.
+//
+// Type is safe for concurrent usage.
+type OnceError struct {
+	mu  sync.RWMutex
+	err error
+	ch  chan struct{}
+}
+
+// NewOnceError return a new OnceError
+func NewOnceError() *OnceError {
+	return &OnceError{
+		ch: make(chan struct{}, 1),
+	}
+}
+
+// Err acquires a read-lock and returns an
+// error if one has been set.
+func (e *OnceError) Err() error {
+	e.mu.RLock()
+	err := e.err
+	e.mu.RUnlock()
+
+	return err
+}
+
+// SetError acquires a write-lock and will set
+// the underlying error value if one has not been set.
+func (e *OnceError) SetError(err error) {
+	if err == nil {
+		return
+	}
+
+	e.mu.Lock()
+	if e.err == nil {
+		e.err = err
+		close(e.ch)
+	}
+	e.mu.Unlock()
+}
+
+// ErrorSet returns a channel that will be used to signal
+// that an error has been set. This channel will be closed
+// when the error value has been set for OnceError.
+func (e *OnceError) ErrorSet() <-chan struct{} {
+	return e.ch
 }

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/shared.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/shared.go
@@ -1,0 +1,23 @@
+package eventstreamapi
+
+// EventStream headers with specific meaning to async API functionality.
+const (
+	ChunkSignatureHeader = `:chunk-signature` // chunk signature for message
+	DateHeader           = `:date`            // Date header for signature
+
+	// Message header and values
+	MessageTypeHeader    = `:message-type` // Identifies type of message.
+	EventMessageType     = `event`
+	ErrorMessageType     = `error`
+	ExceptionMessageType = `exception`
+
+	// Message Events
+	EventTypeHeader = `:event-type` // Identifies message event type e.g. "Stats".
+
+	// Message Error
+	ErrorCodeHeader    = `:error-code`
+	ErrorMessageHeader = `:error-message`
+
+	// Message Exception
+	ExceptionTypeHeader = `:exception-type`
+)

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/signer.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/signer.go
@@ -1,0 +1,123 @@
+package eventstreamapi
+
+import (
+	"bytes"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/private/protocol/eventstream"
+)
+
+var timeNow = time.Now
+
+// StreamSigner defines an interface for the implementation of signing of event stream payloads
+type StreamSigner interface {
+	GetSignature(headers, payload []byte, date time.Time) ([]byte, error)
+}
+
+// SignEncoder envelopes event stream messages
+// into an event stream message payload with included
+// signature headers using the provided signer and encoder.
+type SignEncoder struct {
+	signer     StreamSigner
+	encoder    Encoder
+	bufEncoder *BufferEncoder
+
+	closeErr error
+	closed   bool
+}
+
+// NewSignEncoder returns a new SignEncoder using the provided stream signer and
+// event stream encoder.
+func NewSignEncoder(signer StreamSigner, encoder Encoder) *SignEncoder {
+	// TODO: Need to pass down logging
+
+	return &SignEncoder{
+		signer:     signer,
+		encoder:    encoder,
+		bufEncoder: NewBufferEncoder(),
+	}
+}
+
+// Close encodes a final event stream signing envelope with an empty event stream
+// payload. This final end-frame is used to mark the conclusion of the stream.
+func (s *SignEncoder) Close() error {
+	if s.closed {
+		return s.closeErr
+	}
+
+	if err := s.encode([]byte{}); err != nil {
+		if strings.Contains(err.Error(), "on closed pipe") {
+			return nil
+		}
+
+		s.closeErr = err
+		s.closed = true
+		return s.closeErr
+	}
+
+	return nil
+}
+
+// Encode takes the provided message and add envelopes the message
+// with the required signature.
+func (s *SignEncoder) Encode(msg eventstream.Message) error {
+	payload, err := s.bufEncoder.Encode(msg)
+	if err != nil {
+		return err
+	}
+
+	return s.encode(payload)
+}
+
+func (s SignEncoder) encode(payload []byte) error {
+	date := timeNow()
+
+	var msg eventstream.Message
+	msg.Headers.Set(DateHeader, eventstream.TimestampValue(date))
+	msg.Payload = payload
+
+	var headers bytes.Buffer
+	if err := eventstream.EncodeHeaders(&headers, msg.Headers); err != nil {
+		return err
+	}
+
+	sig, err := s.signer.GetSignature(headers.Bytes(), msg.Payload, date)
+	if err != nil {
+		return err
+	}
+
+	msg.Headers.Set(ChunkSignatureHeader, eventstream.BytesValue(sig))
+
+	return s.encoder.Encode(msg)
+}
+
+// BufferEncoder is a utility that provides a buffered
+// event stream encoder
+type BufferEncoder struct {
+	encoder Encoder
+	buffer  *bytes.Buffer
+}
+
+// NewBufferEncoder returns a new BufferEncoder initialized
+// with a 1024 byte buffer.
+func NewBufferEncoder() *BufferEncoder {
+	buf := bytes.NewBuffer(make([]byte, 1024))
+	return &BufferEncoder{
+		encoder: eventstream.NewEncoder(buf),
+		buffer:  buf,
+	}
+}
+
+// Encode returns the encoded message as a byte slice.
+// The returned byte slice will be modified on the next encode call
+// and should not be held onto.
+func (e *BufferEncoder) Encode(msg eventstream.Message) ([]byte, error) {
+	e.buffer.Reset()
+
+	if err := e.encoder.Encode(msg); err != nil {
+		return nil, err
+	}
+
+	return e.buffer.Bytes(), nil
+}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/stream_writer.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/stream_writer.go
@@ -1,0 +1,129 @@
+package eventstreamapi
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+// StreamWriter provides concurrent safe writing to an event stream.
+type StreamWriter struct {
+	eventWriter *EventWriter
+	stream      chan eventWriteAsyncReport
+
+	done      chan struct{}
+	closeOnce sync.Once
+	err       *OnceError
+
+	streamCloser io.Closer
+}
+
+// NewStreamWriter returns a StreamWriter for the event writer, and stream
+// closer provided.
+func NewStreamWriter(eventWriter *EventWriter, streamCloser io.Closer) *StreamWriter {
+	w := &StreamWriter{
+		eventWriter:  eventWriter,
+		streamCloser: streamCloser,
+		stream:       make(chan eventWriteAsyncReport),
+		done:         make(chan struct{}),
+		err:          NewOnceError(),
+	}
+	go w.writeStream()
+
+	return w
+}
+
+// Close terminates the writers ability to write new events to the stream. Any
+// future call to Send will fail with an error.
+func (w *StreamWriter) Close() error {
+	w.closeOnce.Do(w.safeClose)
+	return w.Err()
+}
+
+func (w *StreamWriter) safeClose() {
+	close(w.done)
+}
+
+// ErrorSet returns a channel which will be closed
+// if an error occurs.
+func (w *StreamWriter) ErrorSet() <-chan struct{} {
+	return w.err.ErrorSet()
+}
+
+// Err returns any error that occurred while attempting to write an event to the
+// stream.
+func (w *StreamWriter) Err() error {
+	return w.err.Err()
+}
+
+// Send writes a single event to the stream returning an error if the write
+// failed.
+//
+// Send may be called concurrently. Events will be written to the stream
+// safely.
+func (w *StreamWriter) Send(ctx aws.Context, event Marshaler) error {
+	if err := w.Err(); err != nil {
+		return err
+	}
+
+	resultCh := make(chan error)
+	wrapped := eventWriteAsyncReport{
+		Event:  event,
+		Result: resultCh,
+	}
+
+	select {
+	case w.stream <- wrapped:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-w.done:
+		return fmt.Errorf("stream closed, unable to send event")
+	}
+
+	select {
+	case err := <-resultCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-w.done:
+		return fmt.Errorf("stream closed, unable to send event")
+	}
+}
+
+func (w *StreamWriter) writeStream() {
+	defer w.Close()
+
+	for {
+		select {
+		case wrapper := <-w.stream:
+			err := w.eventWriter.WriteEvent(wrapper.Event)
+			wrapper.ReportResult(w.done, err)
+			if err != nil {
+				w.err.SetError(err)
+				return
+			}
+
+		case <-w.done:
+			if err := w.streamCloser.Close(); err != nil {
+				w.err.SetError(err)
+			}
+			return
+		}
+	}
+}
+
+type eventWriteAsyncReport struct {
+	Event  Marshaler
+	Result chan<- error
+}
+
+func (e eventWriteAsyncReport) ReportResult(cancel <-chan struct{}, err error) bool {
+	select {
+	case e.Result <- err:
+		return true
+	case <-cancel:
+		return false
+	}
+}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/writer.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/writer.go
@@ -1,0 +1,109 @@
+package eventstreamapi
+
+import (
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/private/protocol/eventstream"
+)
+
+// Marshaler provides a marshaling interface for event types to event stream
+// messages.
+type Marshaler interface {
+	MarshalEvent(protocol.PayloadMarshaler) (eventstream.Message, error)
+}
+
+// Encoder is an stream encoder that will encode an event stream message for
+// the transport.
+type Encoder interface {
+	Encode(eventstream.Message) error
+}
+
+// EventWriter provides a wrapper around the underlying event stream encoder
+// for an io.WriteCloser.
+type EventWriter struct {
+	encoder          Encoder
+	payloadMarshaler protocol.PayloadMarshaler
+	eventTypeFor     func(Marshaler) (string, error)
+}
+
+// NewEventWriter returns a new event stream writer, that will write to the
+// writer provided. Use the WriteEvent method to write an event to the stream.
+func NewEventWriter(encoder Encoder, pm protocol.PayloadMarshaler, eventTypeFor func(Marshaler) (string, error),
+) *EventWriter {
+	return &EventWriter{
+		encoder:          encoder,
+		payloadMarshaler: pm,
+		eventTypeFor:     eventTypeFor,
+	}
+}
+
+// WriteEvent writes an event to the stream. Returns an error if the event
+// fails to marshal into a message, or writing to the underlying writer fails.
+func (w *EventWriter) WriteEvent(event Marshaler) error {
+	msg, err := w.marshal(event)
+	if err != nil {
+		return err
+	}
+
+	return w.encoder.Encode(msg)
+}
+
+func (w *EventWriter) marshal(event Marshaler) (eventstream.Message, error) {
+	eventType, err := w.eventTypeFor(event)
+	if err != nil {
+		return eventstream.Message{}, err
+	}
+
+	msg, err := event.MarshalEvent(w.payloadMarshaler)
+	if err != nil {
+		return eventstream.Message{}, err
+	}
+
+	msg.Headers.Set(EventTypeHeader, eventstream.StringValue(eventType))
+	return msg, nil
+}
+
+//type EventEncoder struct {
+//	encoder           Encoder
+//	ppayloadMarshaler protocol.PayloadMarshaler
+//	eventTypeFor      func(Marshaler) (string, error)
+//}
+//
+//func (e EventEncoder) Encode(event Marshaler) error {
+//	msg, err := e.marshal(event)
+//	if err != nil {
+//		return err
+//	}
+//
+//	return w.encoder.Encode(msg)
+//}
+//
+//func (e EventEncoder) marshal(event Marshaler) (eventstream.Message, error) {
+//	eventType, err := w.eventTypeFor(event)
+//	if err != nil {
+//		return eventstream.Message{}, err
+//	}
+//
+//	msg, err := event.MarshalEvent(w.payloadMarshaler)
+//	if err != nil {
+//		return eventstream.Message{}, err
+//	}
+//
+//	msg.Headers.Set(EventTypeHeader, eventstream.StringValue(eventType))
+//	return msg, nil
+//}
+//
+//func (w *EventWriter) marshal(event Marshaler) (eventstream.Message, error) {
+//	eventType, err := w.eventTypeFor(event)
+//	if err != nil {
+//		return eventstream.Message{}, err
+//	}
+//
+//	msg, err := event.MarshalEvent(w.payloadMarshaler)
+//	if err != nil {
+//		return eventstream.Message{}, err
+//	}
+//
+//	msg.Headers.Set(EventTypeHeader, eventstream.StringValue(eventType))
+//	return msg, nil
+//}
+//

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/header_value.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/header_value.go
@@ -461,6 +461,11 @@ func (v *TimestampValue) decode(r io.Reader) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaler interface
+func (v TimestampValue) MarshalJSON() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
 func timeFromEpochMilli(t int64) time.Time {
 	secs := t / 1e3
 	msec := t % 1e3

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/message.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/message.go
@@ -27,7 +27,7 @@ func (m *Message) rawMessage() (rawMessage, error) {
 
 	if len(m.Headers) > 0 {
 		var headers bytes.Buffer
-		if err := encodeHeaders(&headers, m.Headers); err != nil {
+		if err := EncodeHeaders(&headers, m.Headers); err != nil {
 			return rawMessage{}, err
 		}
 		raw.Headers = headers.Bytes()

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/payload.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/payload.go
@@ -64,7 +64,7 @@ func (h HandlerPayloadMarshal) MarshalPayload(w io.Writer, v interface{}) error 
 		metadata.ClientInfo{},
 		request.Handlers{},
 		nil,
-		&request.Operation{HTTPMethod: "GET"},
+		&request.Operation{HTTPMethod: "PUT"},
 		v,
 		nil,
 	)

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/protocol.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/protocol.go
@@ -1,0 +1,49 @@
+package protocol
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+// RequireHTTPMinProtocol request handler is used to enforce that
+// the target endpoint supports the given major and minor HTTP protocol version.
+type RequireHTTPMinProtocol struct {
+	Major, Minor int
+}
+
+// Handler will mark the request.Request with an error if the
+// target endpoint did not connect with the required HTTP protocol
+// major and minor version.
+func (p RequireHTTPMinProtocol) Handler(r *request.Request) {
+	if r.Error != nil || r.HTTPResponse == nil {
+		return
+	}
+
+	if !strings.HasPrefix(r.HTTPResponse.Proto, "HTTP") {
+		r.Error = newMinHTTPProtoError(p.Major, p.Minor, r)
+	}
+
+	if r.HTTPResponse.ProtoMajor < p.Major || r.HTTPResponse.ProtoMinor < p.Minor {
+		r.Error = newMinHTTPProtoError(p.Major, p.Minor, r)
+	}
+}
+
+// ErrCodeMinimumHTTPProtocolError error code is returned when the target endpoint
+// did not match the required HTTP major and minor protocol version.
+const ErrCodeMinimumHTTPProtocolError = "MinimumHTTPProtocolError"
+
+func newMinHTTPProtoError(major, minor int, r *request.Request) error {
+	return awserr.NewRequestFailure(
+		awserr.New("MinimumHTTPProtocolError",
+			fmt.Sprintf(
+				"operation requires minimum HTTP protocol of HTTP/%d.%d, but was %s",
+				major, minor, r.HTTPResponse.Proto,
+			),
+			nil,
+		),
+		r.HTTPResponse.StatusCode, r.RequestID,
+	)
+}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/query/build.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/query/build.go
@@ -1,7 +1,7 @@
 // Package query provides serialization of AWS query requests, and responses.
 package query
 
-//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/query.json build_test.go
+//go:generate go run -tags codegen ../../../private/model/cli/gen-protocol-tests ../../../models/protocol_tests/input/query.json build_test.go
 
 import (
 	"net/url"

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/query/unmarshal.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/query/unmarshal.go
@@ -1,6 +1,6 @@
 package query
 
-//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/query.json unmarshal_test.go
+//go:generate go run -tags codegen ../../../private/model/cli/gen-protocol-tests ../../../models/protocol_tests/output/query.json unmarshal_test.go
 
 import (
 	"encoding/xml"

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/unmarshal.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/unmarshal.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	awsStrings "github.com/aws/aws-sdk-go/internal/strings"
 	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
@@ -28,7 +29,9 @@ var UnmarshalMetaHandler = request.NamedHandler{Name: "awssdk.rest.UnmarshalMeta
 func Unmarshal(r *request.Request) {
 	if r.DataFilled() {
 		v := reflect.Indirect(reflect.ValueOf(r.Data))
-		unmarshalBody(r, v)
+		if err := unmarshalBody(r, v); err != nil {
+			r.Error = err
+		}
 	}
 }
 
@@ -40,12 +43,21 @@ func UnmarshalMeta(r *request.Request) {
 		r.RequestID = r.HTTPResponse.Header.Get("X-Amz-Request-Id")
 	}
 	if r.DataFilled() {
-		v := reflect.Indirect(reflect.ValueOf(r.Data))
-		unmarshalLocationElements(r, v)
+		if err := UnmarshalResponse(r.HTTPResponse, r.Data, aws.BoolValue(r.Config.LowerCaseHeaderMaps)); err != nil {
+			r.Error = err
+		}
 	}
 }
 
-func unmarshalBody(r *request.Request, v reflect.Value) {
+// UnmarshalResponse attempts to unmarshal the REST response headers to
+// the data type passed in. The type must be a pointer. An error is returned
+// with any error unmarshaling the response into the target datatype.
+func UnmarshalResponse(resp *http.Response, data interface{}, lowerCaseHeaderMaps bool) error {
+	v := reflect.Indirect(reflect.ValueOf(data))
+	return unmarshalLocationElements(resp, v, lowerCaseHeaderMaps)
+}
+
+func unmarshalBody(r *request.Request, v reflect.Value) error {
 	if field, ok := v.Type().FieldByName("_"); ok {
 		if payloadName := field.Tag.Get("payload"); payloadName != "" {
 			pfield, _ := v.Type().FieldByName(payloadName)
@@ -57,35 +69,38 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						defer r.HTTPResponse.Body.Close()
 						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
-							r.Error = awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
-						} else {
-							payload.Set(reflect.ValueOf(b))
+							return awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 						}
+
+						payload.Set(reflect.ValueOf(b))
+
 					case *string:
 						defer r.HTTPResponse.Body.Close()
 						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
-							r.Error = awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
-						} else {
-							str := string(b)
-							payload.Set(reflect.ValueOf(&str))
+							return awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 						}
+
+						str := string(b)
+						payload.Set(reflect.ValueOf(&str))
+
 					default:
 						switch payload.Type().String() {
 						case "io.ReadCloser":
 							payload.Set(reflect.ValueOf(r.HTTPResponse.Body))
+
 						case "io.ReadSeeker":
 							b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 							if err != nil {
-								r.Error = awserr.New(request.ErrCodeSerialization,
+								return awserr.New(request.ErrCodeSerialization,
 									"failed to read response body", err)
-								return
 							}
 							payload.Set(reflect.ValueOf(ioutil.NopCloser(bytes.NewReader(b))))
+
 						default:
 							io.Copy(ioutil.Discard, r.HTTPResponse.Body)
-							defer r.HTTPResponse.Body.Close()
-							r.Error = awserr.New(request.ErrCodeSerialization,
+							r.HTTPResponse.Body.Close()
+							return awserr.New(request.ErrCodeSerialization,
 								"failed to decode REST response",
 								fmt.Errorf("unknown payload type %s", payload.Type()))
 						}
@@ -94,9 +109,11 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 			}
 		}
 	}
+
+	return nil
 }
 
-func unmarshalLocationElements(r *request.Request, v reflect.Value) {
+func unmarshalLocationElements(resp *http.Response, v reflect.Value, lowerCaseHeaderMaps bool) error {
 	for i := 0; i < v.NumField(); i++ {
 		m, field := v.Field(i), v.Type().Field(i)
 		if n := field.Name; n[0:1] == strings.ToLower(n[0:1]) {
@@ -111,26 +128,25 @@ func unmarshalLocationElements(r *request.Request, v reflect.Value) {
 
 			switch field.Tag.Get("location") {
 			case "statusCode":
-				unmarshalStatusCode(m, r.HTTPResponse.StatusCode)
+				unmarshalStatusCode(m, resp.StatusCode)
+
 			case "header":
-				err := unmarshalHeader(m, r.HTTPResponse.Header.Get(name), field.Tag)
+				err := unmarshalHeader(m, resp.Header.Get(name), field.Tag)
 				if err != nil {
-					r.Error = awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
-					break
+					return awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 				}
+
 			case "headers":
 				prefix := field.Tag.Get("locationName")
-				err := unmarshalHeaderMap(m, r.HTTPResponse.Header, prefix)
+				err := unmarshalHeaderMap(m, resp.Header, prefix, lowerCaseHeaderMaps)
 				if err != nil {
-					r.Error = awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
-					break
+					awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 				}
 			}
 		}
-		if r.Error != nil {
-			return
-		}
 	}
+
+	return nil
 }
 
 func unmarshalStatusCode(v reflect.Value, statusCode int) {
@@ -145,7 +161,7 @@ func unmarshalStatusCode(v reflect.Value, statusCode int) {
 	}
 }
 
-func unmarshalHeaderMap(r reflect.Value, headers http.Header, prefix string) error {
+func unmarshalHeaderMap(r reflect.Value, headers http.Header, prefix string, normalize bool) error {
 	if len(headers) == 0 {
 		return nil
 	}
@@ -153,8 +169,12 @@ func unmarshalHeaderMap(r reflect.Value, headers http.Header, prefix string) err
 	case map[string]*string: // we only support string map value types
 		out := map[string]*string{}
 		for k, v := range headers {
-			k = http.CanonicalHeaderKey(k)
-			if strings.HasPrefix(strings.ToLower(k), strings.ToLower(prefix)) {
+			if awsStrings.HasPrefixFold(k, prefix) {
+				if normalize == true {
+					k = strings.ToLower(k)
+				} else {
+					k = http.CanonicalHeaderKey(k)
+				}
 				out[k[len(prefix):]] = &v[0]
 			}
 		}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/restxml/restxml.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/restxml/restxml.go
@@ -2,8 +2,8 @@
 // requests and responses.
 package restxml
 
-//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/input/rest-xml.json build_test.go
-//go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/rest-xml.json unmarshal_test.go
+//go:generate go run -tags codegen ../../../private/model/cli/gen-protocol-tests ../../../models/protocol_tests/input/rest-xml.json build_test.go
+//go:generate go run -tags codegen ../../../private/model/cli/gen-protocol-tests ../../../models/protocol_tests/output/rest-xml.json unmarshal_test.go
 
 import (
 	"bytes"

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/unmarshal.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/unmarshal.go
@@ -19,3 +19,9 @@ func UnmarshalDiscardBody(r *request.Request) {
 	io.Copy(ioutil.Discard, r.HTTPResponse.Body)
 	r.HTTPResponse.Body.Close()
 }
+
+// ResponseMetadata provides the SDK response metadata attributes.
+type ResponseMetadata struct {
+	StatusCode int
+	RequestID  string
+}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/unmarshal_error.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/unmarshal_error.go
@@ -1,0 +1,65 @@
+package protocol
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+// UnmarshalErrorHandler provides unmarshaling errors API response errors for
+// both typed and untyped errors.
+type UnmarshalErrorHandler struct {
+	unmarshaler ErrorUnmarshaler
+}
+
+// ErrorUnmarshaler is an abstract interface for concrete implementations to
+// unmarshal protocol specific response errors.
+type ErrorUnmarshaler interface {
+	UnmarshalError(*http.Response, ResponseMetadata) (error, error)
+}
+
+// NewUnmarshalErrorHandler returns an UnmarshalErrorHandler
+// initialized for the set of exception names to the error unmarshalers
+func NewUnmarshalErrorHandler(unmarshaler ErrorUnmarshaler) *UnmarshalErrorHandler {
+	return &UnmarshalErrorHandler{
+		unmarshaler: unmarshaler,
+	}
+}
+
+// UnmarshalErrorHandlerName is the name of the named handler.
+const UnmarshalErrorHandlerName = "awssdk.protocol.UnmarshalError"
+
+// NamedHandler returns a NamedHandler for the unmarshaler using the set of
+// errors the unmarshaler was initialized for.
+func (u *UnmarshalErrorHandler) NamedHandler() request.NamedHandler {
+	return request.NamedHandler{
+		Name: UnmarshalErrorHandlerName,
+		Fn:   u.UnmarshalError,
+	}
+}
+
+// UnmarshalError will attempt to unmarshal the API response's error message
+// into either a generic SDK error type, or a typed error corresponding to the
+// errors exception name.
+func (u *UnmarshalErrorHandler) UnmarshalError(r *request.Request) {
+	defer r.HTTPResponse.Body.Close()
+
+	respMeta := ResponseMetadata{
+		StatusCode: r.HTTPResponse.StatusCode,
+		RequestID:  r.RequestID,
+	}
+
+	v, err := u.unmarshaler.UnmarshalError(r.HTTPResponse, respMeta)
+	if err != nil {
+		r.Error = awserr.NewRequestFailure(
+			awserr.New(request.ErrCodeSerialization,
+				"failed to unmarshal response error", err),
+			respMeta.StatusCode,
+			respMeta.RequestID,
+		)
+		return
+	}
+
+	r.Error = v
+}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/build.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/build.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/private/protocol"
@@ -58,6 +59,14 @@ func (b *xmlBuilder) buildValue(value reflect.Value, current *XMLNode, tag refle
 		return nil
 	} else if tag.Get("location") != "" { // don't handle non-body location values
 		return nil
+	}
+
+	xml := tag.Get("xml")
+	if len(xml) != 0 {
+		name := strings.SplitAfterN(xml, ",", 2)[0]
+		if name == "-" {
+			return nil
+		}
 	}
 
 	t := tag.Get("type")

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/unmarshal.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/unmarshal.go
@@ -64,6 +64,14 @@ func UnmarshalXML(v interface{}, d *xml.Decoder, wrapper string) error {
 // parse deserializes any value from the XMLNode. The type tag is used to infer the type, or reflect
 // will be used to determine the type from r.
 func parse(r reflect.Value, node *XMLNode, tag reflect.StructTag) error {
+	xml := tag.Get("xml")
+	if len(xml) != 0 {
+		name := strings.SplitAfterN(xml, ",", 2)[0]
+		if name == "-" {
+			return nil
+		}
+	}
+
 	rtype := r.Type()
 	if rtype.Kind() == reflect.Ptr {
 		rtype = rtype.Elem() // check kind of actual element type

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/pool.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/pool.go
@@ -1,0 +1,244 @@
+package s3manager
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+type byteSlicePool interface {
+	Get(aws.Context) (*[]byte, error)
+	Put(*[]byte)
+	ModifyCapacity(int)
+	SliceSize() int64
+	Close()
+}
+
+type maxSlicePool struct {
+	// allocator is defined as a function pointer to allow
+	// for test cases to instrument custom tracers when allocations
+	// occur.
+	allocator sliceAllocator
+
+	slices         chan *[]byte
+	allocations    chan struct{}
+	capacityChange chan struct{}
+
+	max       int
+	sliceSize int64
+
+	mtx sync.RWMutex
+}
+
+func newMaxSlicePool(sliceSize int64) *maxSlicePool {
+	p := &maxSlicePool{sliceSize: sliceSize}
+	p.allocator = p.newSlice
+
+	return p
+}
+
+var errZeroCapacity = fmt.Errorf("get called on zero capacity pool")
+
+func (p *maxSlicePool) Get(ctx aws.Context) (*[]byte, error) {
+	// check if context is canceled before attempting to get a slice
+	// this ensures priority is given to the cancel case first
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	p.mtx.RLock()
+
+	for {
+		select {
+		case bs, ok := <-p.slices:
+			p.mtx.RUnlock()
+			if !ok {
+				// attempt to get on a zero capacity pool
+				return nil, errZeroCapacity
+			}
+			return bs, nil
+		case _, ok := <-p.allocations:
+			p.mtx.RUnlock()
+			if !ok {
+				// attempt to get on a zero capacity pool
+				return nil, errZeroCapacity
+			}
+			return p.allocator(), nil
+		case <-ctx.Done():
+			p.mtx.RUnlock()
+			return nil, ctx.Err()
+		default:
+			// In the event that there are no slices or allocations available
+			// This prevents some deadlock situations that can occur around sync.RWMutex
+			// When a lock request occurs on ModifyCapacity, no new readers are allowed to acquire a read lock.
+			// By releasing the read lock here and waiting for a notification, we prevent a deadlock situation where
+			// Get could hold the read lock indefinitely waiting for capacity, ModifyCapacity is waiting for a write lock,
+			// and a Put is blocked trying to get a read-lock which is blocked by ModifyCapacity.
+
+			// Short-circuit if the pool capacity is zero.
+			if p.max == 0 {
+				p.mtx.RUnlock()
+				return nil, errZeroCapacity
+			}
+
+			// Since we will be releasing the read-lock we need to take the reference to the channel.
+			// Since channels are references we will still get notified if slices are added, or if
+			// the channel is closed due to a capacity modification. This specifically avoids a data race condition
+			// where ModifyCapacity both closes a channel and initializes a new one while we don't have a read-lock.
+			c := p.capacityChange
+
+			p.mtx.RUnlock()
+
+			select {
+			case _ = <-c:
+				p.mtx.RLock()
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+	}
+}
+
+func (p *maxSlicePool) Put(bs *[]byte) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	if p.max == 0 {
+		return
+	}
+
+	select {
+	case p.slices <- bs:
+		p.notifyCapacity()
+	default:
+		// If the new channel when attempting to add the slice then we drop the slice.
+		// The logic here is to prevent a deadlock situation if channel is already at max capacity.
+		// Allows us to reap allocations that are returned and are no longer needed.
+	}
+}
+
+func (p *maxSlicePool) ModifyCapacity(delta int) {
+	if delta == 0 {
+		return
+	}
+
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	p.max += delta
+
+	if p.max == 0 {
+		p.empty()
+		return
+	}
+
+	if p.capacityChange != nil {
+		close(p.capacityChange)
+	}
+	p.capacityChange = make(chan struct{}, p.max)
+
+	origAllocations := p.allocations
+	p.allocations = make(chan struct{}, p.max)
+
+	newAllocs := len(origAllocations) + delta
+	for i := 0; i < newAllocs; i++ {
+		p.allocations <- struct{}{}
+	}
+
+	if origAllocations != nil {
+		close(origAllocations)
+	}
+
+	origSlices := p.slices
+	p.slices = make(chan *[]byte, p.max)
+	if origSlices == nil {
+		return
+	}
+
+	close(origSlices)
+	for bs := range origSlices {
+		select {
+		case p.slices <- bs:
+		default:
+			// If the new channel blocks while adding slices from the old channel
+			// then we drop the slice. The logic here is to prevent a deadlock situation
+			// if the new channel has a smaller capacity then the old.
+		}
+	}
+}
+
+func (p *maxSlicePool) notifyCapacity() {
+	select {
+	case p.capacityChange <- struct{}{}:
+	default:
+		// This *shouldn't* happen as the channel is both buffered to the max pool capacity size and is resized
+		// on capacity modifications. This is just a safety to ensure that a blocking situation can't occur.
+	}
+}
+
+func (p *maxSlicePool) SliceSize() int64 {
+	return p.sliceSize
+}
+
+func (p *maxSlicePool) Close() {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.empty()
+}
+
+func (p *maxSlicePool) empty() {
+	p.max = 0
+
+	if p.capacityChange != nil {
+		close(p.capacityChange)
+		p.capacityChange = nil
+	}
+
+	if p.allocations != nil {
+		close(p.allocations)
+		for range p.allocations {
+			// drain channel
+		}
+		p.allocations = nil
+	}
+
+	if p.slices != nil {
+		close(p.slices)
+		for range p.slices {
+			// drain channel
+		}
+		p.slices = nil
+	}
+}
+
+func (p *maxSlicePool) newSlice() *[]byte {
+	bs := make([]byte, p.sliceSize)
+	return &bs
+}
+
+type returnCapacityPoolCloser struct {
+	byteSlicePool
+	returnCapacity int
+}
+
+func (n *returnCapacityPoolCloser) ModifyCapacity(delta int) {
+	if delta > 0 {
+		n.returnCapacity = -1 * delta
+	}
+	n.byteSlicePool.ModifyCapacity(delta)
+}
+
+func (n *returnCapacityPoolCloser) Close() {
+	if n.returnCapacity < 0 {
+		n.byteSlicePool.ModifyCapacity(n.returnCapacity)
+	}
+}
+
+type sliceAllocator func() *[]byte
+
+var newByteSlicePool = func(sliceSize int64) byteSlicePool {
+	return newMaxSlicePool(sliceSize)
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/upload.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/upload.go
@@ -167,7 +167,7 @@ type Uploader struct {
 	BufferProvider ReadSeekerWriteToProvider
 
 	// partPool allows for the re-usage of streaming payload part buffers between upload calls
-	partPool *partPool
+	partPool byteSlicePool
 }
 
 // NewUploader creates a new Uploader instance to upload objects to S3. Pass In
@@ -204,7 +204,7 @@ func newUploader(client s3iface.S3API, options ...func(*Uploader)) *Uploader {
 		option(u)
 	}
 
-	u.partPool = newPartPool(u.PartSize)
+	u.partPool = newByteSlicePool(u.PartSize)
 
 	return u
 }
@@ -366,6 +366,7 @@ func (u *uploader) upload() (*UploadOutput, error) {
 	if err := u.init(); err != nil {
 		return nil, awserr.New("ReadRequestBody", "unable to initialize upload", err)
 	}
+	defer u.cfg.partPool.Close()
 
 	if u.cfg.PartSize < MinUploadPartSize {
 		msg := fmt.Sprintf("part size must be at least %d bytes", MinUploadPartSize)
@@ -404,8 +405,13 @@ func (u *uploader) init() error {
 
 	// If PartSize was changed or partPool was never setup then we need to allocated a new pool
 	// so that we return []byte slices of the correct size
-	if u.cfg.partPool == nil || u.cfg.partPool.partSize != u.cfg.PartSize {
-		u.cfg.partPool = newPartPool(u.cfg.PartSize)
+	poolCap := u.cfg.Concurrency + 1
+	if u.cfg.partPool == nil || u.cfg.partPool.SliceSize() != u.cfg.PartSize {
+		u.cfg.partPool = newByteSlicePool(u.cfg.PartSize)
+		u.cfg.partPool.ModifyCapacity(poolCap)
+	} else {
+		u.cfg.partPool = &returnCapacityPoolCloser{byteSlicePool: u.cfg.partPool}
+		u.cfg.partPool.ModifyCapacity(poolCap)
 	}
 
 	return nil
@@ -441,10 +447,6 @@ func (u *uploader) initSize() error {
 // does not need to be wrapped in a mutex because nextReader is only called
 // from the main thread.
 func (u *uploader) nextReader() (io.ReadSeeker, int, func(), error) {
-	type readerAtSeeker interface {
-		io.ReaderAt
-		io.ReadSeeker
-	}
 	switch r := u.in.Body.(type) {
 	case readerAtSeeker:
 		var err error
@@ -476,15 +478,19 @@ func (u *uploader) nextReader() (io.ReadSeeker, int, func(), error) {
 		return reader, int(n), cleanup, err
 
 	default:
-		part := u.cfg.partPool.Get().([]byte)
-		n, err := readFillBuf(r, part)
+		part, err := u.cfg.partPool.Get(u.ctx)
+		if err != nil {
+			return nil, 0, func() {}, err
+		}
+
+		n, err := readFillBuf(r, *part)
 		u.readerPos += int64(n)
 
 		cleanup := func() {
 			u.cfg.partPool.Put(part)
 		}
 
-		return bytes.NewReader(part[0:n]), n, cleanup, err
+		return bytes.NewReader((*part)[0:n]), n, cleanup, err
 	}
 }
 
@@ -558,6 +564,7 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker, cleanup func()) (*UploadO
 	// Create the multipart
 	resp, err := u.cfg.S3.CreateMultipartUploadWithContext(u.ctx, params, u.cfg.RequestOptions...)
 	if err != nil {
+		cleanup()
 		return nil, err
 	}
 	u.uploadID = *resp.UploadId
@@ -672,6 +679,8 @@ func (u *multiuploader) readChunk(ch chan chunk) {
 				u.seterr(err)
 			}
 		}
+
+		data.cleanup()
 	}
 }
 
@@ -689,7 +698,6 @@ func (u *multiuploader) send(c chunk) error {
 	}
 
 	resp, err := u.cfg.S3.UploadPartWithContext(u.ctx, params, u.cfg.RequestOptions...)
-	c.cleanup()
 	if err != nil {
 		return err
 	}
@@ -762,17 +770,7 @@ func (u *multiuploader) complete() *s3.CompleteMultipartUploadOutput {
 	return resp
 }
 
-type partPool struct {
-	partSize int64
-	sync.Pool
-}
-
-func newPartPool(partSize int64) *partPool {
-	p := &partPool{partSize: partSize}
-
-	p.New = func() interface{} {
-		return make([]byte, p.partSize)
-	}
-
-	return p
+type readerAtSeeker interface {
+	io.ReaderAt
+	io.ReadSeeker
 }

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/service.go
@@ -78,6 +78,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint,
 	svc.Handlers.UnmarshalMeta.PushBackNamed(restxml.UnmarshalMetaHandler)
 	svc.Handlers.UnmarshalError.PushBackNamed(restxml.UnmarshalErrorHandler)
 
+	svc.Handlers.BuildStream.PushBackNamed(restxml.BuildHandler)
 	svc.Handlers.UnmarshalStream.PushBackNamed(restxml.UnmarshalHandler)
 
 	// Run custom client initialization if present


### PR DESCRIPTION
Thanks for a very nice plugin!

I've added support for using [IRSA](https://aws.amazon.com/jp/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) in AWS EKS.

- Changed the AWS SDK for Go version to the latest version that is greater than `1.23.13` with IRSA support
- Changed to do the [default credential reading](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials) of AWS SDK for Go the `AccessKeyID `,`SecretAccessKey` and `Credential ` are not defined.

###  Tested cases

I have checked the following cases to work with EKS v1.14 and fluent-bit v1.3.11.

#### Shared Credentials
```
[OUTPUT]
    Name         s3
    Match         kube.*
    Bucket        mybuckets
    Credential  /path/to/credentials
    S3Prefix     path/to
    Region        ap-northeast-1
    Compress  gzip
```

#### Static Credentials
```
[OUTPUT]
    Name                    s3
    Match                   kube.*
    Bucket                  mybuckets
    AccessKeyID        myaccesskey
    SecretAccessKey mysecretskey
    S3Prefix                path/to
    Region                  ap-northeast-1
    Compress             gzip
```

#### Environment Credentials
```
[OUTPUT]
    Name        s3
    Match       kube.*
    Bucket      mybuckets
    S3Prefix   path/to
    Region      ap-northeast-1
    Compress gzip
```

```
env:
  - name: AWS_ACCESS_KEY_ID
     value: myaccesskey
  - name: AWS_SECRET_ACCESS_KEY
     value: mysecretkey
```

I injected environment variables into the fluent-bit pod in kubernetes.

#### IRSA

```
[OUTPUT]
    Name        s3
    Match       kube.*
    Bucket      mybuckets
    S3Prefix   path/to
    Region      ap-northeast-1
    Compress gzip
```

```
serviceAccount: my-irsa-sa
```

I injected IRSA-enabled service account in kubernetes into fluent-bit's pod.

