### PR TITLE
Added a TimeFormat option

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/README.md
+++ b/README.md
@@ -65,19 +65,20 @@ $ make
 
 ### Configuration Options
 
-| Key              | Description                   | Default value | Note                            |
-|------------------|-------------------------------|---------------|---------------------------------|
-| Credential       | URI of AWS shared credential  | `""`          |(See [Credentials](#credentials))|
-| AccessKeyID      | Access key ID of AWS          | `""`          |(See [Credentials](#credentials))|
-| SecretAccessKey  | Secret access key ID of AWS   | `""`          |(See [Credentials](#credentials))|
-| Bucket           | Bucket name of S3 storage     | `-`           | Mandatory parameter             |
-| S3Prefix         | S3Prefix of S3 key            | `-`           | Mandatory parameter             |
-| Region           | Region of S3                  | `-`           | Mandatory parameter             |
-| Compress         | Choose Compress method        | `""`          | gzip or plainText(`""`)         |
-| Endpoint         | Specify the endpoint URL      | `""`          | URL with port or empty string   |
-| AutoCreateBucket | Create bucket automatically   | `false`       | true/false                      |
-| LogLevel         | Specify Log Level             | `"info"`      | trace/debug/info/warning/error/fatal/panic     |
-| TimeZone         | Specify TimeZone              | `""`          | Specify TZInfo based region. e.g.) Asia/Tokyo     |
+| Key              | Description                       | Default value   | Note                                                                 |
+|------------------|-----------------------------------|-----------------|----------------------------------------------------------------------|
+| Credential       | URI of AWS shared credential      | `""`            | (See [Credentials](#credentials))                                    |
+| AccessKeyID      | Access key ID of AWS              | `""`            | (See [Credentials](#credentials))                                    |
+| SecretAccessKey  | Secret access key ID of AWS       | `""`            | (See [Credentials](#credentials))                                    |
+| Bucket           | Bucket name of S3 storage         | `-`             | Mandatory parameter                                                  |
+| S3Prefix         | S3Prefix of S3 key                | `-`             | Mandatory parameter                                                  |
+| Region           | Region of S3                      | `-`             | Mandatory parameter                                                  |
+| Compress         | Choose Compress method            | `""`            | gzip or plainText(`""`)                                              |
+| Endpoint         | Specify the endpoint URL          | `""`            | URL with port or empty string                                        |
+| AutoCreateBucket | Create bucket automatically       | `false`         | true/false                                                           |
+| LogLevel         | Specify Log Level                 | `"info"`        | trace/debug/info/warning/error/fatal/panic                           |
+| TimeFormat       | Time format to add to the S3 path | `"20060102/15"` | Specify in [Go's Time Format](https://golang.org/src/time/format.go) | 
+| TimeZone         | Specify TimeZone                  | `""`            | Specify TZInfo based region. e.g.) Asia/Tokyo                        |
 
 Example:
 
@@ -96,6 +97,7 @@ Add this section to fluent-bit.conf:
     Compress gzip
     # Endpoint parameter is mainly used for minio.
     # Endpoint http://localhost:9000
+    # TimeFormat 20060102/15
     # TimeZone Asia/Tokyo
 ```
 

--- a/out_s3_test.go
+++ b/out_s3_test.go
@@ -297,7 +297,7 @@ func (c *testS3Credential) GetCredentials(accessID, secretkey, credential string
 
 func TestPluginInitializationWithStaticCredentials(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "examplebucket", "exampleregion", "", "", "false", "info", "")
+	_, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "examplebucket", "exampleregion", "", "", "false", "info", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -318,7 +318,7 @@ func TestPluginInitializationWithStaticCredentials(t *testing.T) {
 
 func TestPluginInitializationWithSharedCredentials(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "", "", "false", "info", "")
+	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "", "", "false", "info", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}

--- a/s3.go
+++ b/s3.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/aws/aws-sdk-go/aws"
+import (
+	"github.com/aws/aws-sdk-go/aws"
+)
 import "github.com/aws/aws-sdk-go/aws/credentials"
 import log "github.com/sirupsen/logrus"
 
@@ -26,6 +28,7 @@ type s3Config struct {
 	compress         format
 	endpoint         string
 	logLevel         log.Level
+	timeFormat       string
 	location         *time.Location
 	autoCreateBucket bool
 }
@@ -66,7 +69,7 @@ func (c *s3PluginConfig) GetCredentials(accessKeyID, secretKey, credential strin
 	return nil, fmt.Errorf("Failed to create credentials")
 }
 
-func getS3Config(accessID, secretKey, credential, s3prefix, bucket, region, compress, endpoint, autoCreateBucket, logLevel, timeZone string) (*s3Config, error) {
+func getS3Config(accessID, secretKey, credential, s3prefix, bucket, region, compress, endpoint, autoCreateBucket, logLevel, timeFormat, timeZone string) (*s3Config, error) {
 	conf := &s3Config{}
 	creds, err := s3Creds.GetCredentials(accessID, secretKey, credential)
 	if err != nil {
@@ -118,6 +121,12 @@ func getS3Config(accessID, secretKey, credential, s3prefix, bucket, region, comp
 		return nil, fmt.Errorf("invalid log level: %v", logLevel)
 	}
 	conf.logLevel = level
+
+	if timeFormat != "" {
+		conf.timeFormat = timeFormat
+	} else {
+		conf.timeFormat = "20060102/15"
+	}
 
 	if timeZone != "" {
 		loc, err := time.LoadLocation(timeZone)

--- a/s3_test.go
+++ b/s3_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGetS3ConfigStaticCredentials(t *testing.T) {
-	conf, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "examplebucket", "exampleregion", "", "", "", "", "")
+	conf, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "examplebucket", "exampleregion", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -23,7 +23,7 @@ func TestGetS3ConfigStaticCredentials(t *testing.T) {
 
 func TestGetS3ConfigSharedCredentials(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "", "", "", "", "")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -38,7 +38,7 @@ func TestGetS3ConfigSharedCredentials(t *testing.T) {
 
 func TestGetS3ConfigCompression(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -53,7 +53,7 @@ func TestGetS3ConfigCompression(t *testing.T) {
 
 func TestGetS3ConfigEndpoint(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "http://localhost:9000", "false", "", "")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "http://localhost:9000", "false", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -69,16 +69,16 @@ func TestGetS3ConfigEndpoint(t *testing.T) {
 
 func TestGetS3ConfigInvalidEndpoint(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "https://your-bucketname.s3.amazonaws.com", "false", "", "")
+	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "https://your-bucketname.s3.amazonaws.com", "false", "", "", "")
 	if err != nil {
 		expected := errors.New("Endpoint is not supported for AWS S3. This parameter is intended for S3 compatible services. Use Region instead.")
 		assert.Equal(t, expected, err)
 	}
 }
 
-func TestGetS3ConfigTimeZone(t *testing.T) {
+func TestGetS3ConfigTimeFormat(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "Asia/Tokyo")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "dt=2006-01-02", "Asia/Tokyo")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -89,13 +89,32 @@ func TestGetS3ConfigTimeZone(t *testing.T) {
 	assert.Equal(t, "exampleregion", *conf.region, "Specify s3prefix name")
 	assert.Equal(t, gzipFormat, conf.compress, "Specify compression method")
 	assert.Equal(t, false, conf.autoCreateBucket, "Specify true/false")
+	assert.Equal(t, "dt=2006-01-02", conf.timeFormat, "Specify time format")
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	assert.Equal(t, loc, conf.location, "Specify valid TimeZone")
+}
+
+func TestGetS3ConfigTimeZone(t *testing.T) {
+	s3Creds = &testS3Credential{}
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "", "Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("failed test %#v", err)
+	}
+
+	assert.Equal(t, "examplebucket", *conf.bucket, "Specify bucket name")
+	assert.Equal(t, "exampleprefix", *conf.s3prefix, "Specify s3prefix name")
+	assert.NotNil(t, conf.credentials, "credentials not to be nil")
+	assert.Equal(t, "exampleregion", *conf.region, "Specify s3prefix name")
+	assert.Equal(t, gzipFormat, conf.compress, "Specify compression method")
+	assert.Equal(t, false, conf.autoCreateBucket, "Specify true/false")
+	assert.Equal(t, "20060102/15", conf.timeFormat, "Specify time format")
 	loc, _ := time.LoadLocation("Asia/Tokyo")
 	assert.Equal(t, loc, conf.location, "Specify valid TimeZone")
 }
 
 func TestGetS3ConfigInvalidTimeZone(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "Asia/Nonexistent")
+	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "", "Asia/Nonexistent")
 	if err != nil {
 		expected := errors.New("invalid timeZone: unknown time zone Asia/Nonexistent")
 		assert.Equal(t, expected, err)


### PR DESCRIPTION
Added a TimeFormat option https://github.com/cosmo0920/fluent-bit-go-s3/issues/25 

```
[Output]
    Name s3
    Match *
    AccessKeyID     yourawsaccesskeyid
    SecretAccessKey yourawssecretaccesskey
    Bucket          yourbucketname
    S3Prefix yours3prefixname
    TimeFormat dt=2006-01-02
    Region us-east-1
    Compress gzip
```

The path to create in S3 will be `s3://yourbucketname/yours3prefixname/dt=yyyy-mm-dd/yyyymmddhhiiss.log.gz`.
