### PR TITLE
Fixed to put an existing S3 object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,21 @@ $ make
 
 ### Configuration Options
 
-| Key              | Description                       | Default value   | Note                                                                 |
-|------------------|-----------------------------------|-----------------|----------------------------------------------------------------------|
-| Credential       | URI of AWS shared credential      | `""`            | (See [Credentials](#credentials))                                    |
-| AccessKeyID      | Access key ID of AWS              | `""`            | (See [Credentials](#credentials))                                    |
-| SecretAccessKey  | Secret access key ID of AWS       | `""`            | (See [Credentials](#credentials))                                    |
-| Bucket           | Bucket name of S3 storage         | `-`             | Mandatory parameter                                                  |
-| S3Prefix         | S3Prefix of S3 key                | `-`             | Mandatory parameter                                                  |
-| Region           | Region of S3                      | `-`             | Mandatory parameter                                                  |
-| Compress         | Choose Compress method            | `""`            | gzip or plainText(`""`)                                              |
-| Endpoint         | Specify the endpoint URL          | `""`            | URL with port or empty string                                        |
-| AutoCreateBucket | Create bucket automatically       | `false`         | true/false                                                           |
-| LogLevel         | Specify Log Level                 | `"info"`        | trace/debug/info/warning/error/fatal/panic                           |
-| TimeFormat       | Time format to add to the S3 path | `"20060102/15"` | Specify in [Go's Time Format](https://golang.org/src/time/format.go) | 
-| TimeZone         | Specify TimeZone                  | `""`            | Specify TZInfo based region. e.g.) Asia/Tokyo                        |
+| Key              | Description                           | Default value   | Note                                                                 |
+|------------------|---------------------------------------|-----------------|----------------------------------------------------------------------|
+| Credential       | URI of AWS shared credential          | `""`            | (See [Credentials](#credentials))                                    |
+| AccessKeyID      | Access key ID of AWS                  | `""`            | (See [Credentials](#credentials))                                    |
+| SecretAccessKey  | Secret access key ID of AWS           | `""`            | (See [Credentials](#credentials))                                    |
+| Bucket           | Bucket name of S3 storage             | `-`             | Mandatory parameter                                                  |
+| S3Prefix         | S3Prefix of S3 key                    | `-`             | Mandatory parameter                                                  |
+| SuffixAlgorithm  | Algorithm for naming S3 object suffix | `""`            | sha256 or no suffix(`""`)                                            |
+| Region           | Region of S3                          | `-`             | Mandatory parameter                                                  |
+| Compress         | Choose Compress method                | `""`            | gzip or plainText(`""`)                                              |
+| Endpoint         | Specify the endpoint URL              | `""`            | URL with port or empty string                                        |
+| AutoCreateBucket | Create bucket automatically           | `false`         | true/false                                                           |
+| LogLevel         | Specify Log Level                     | `"info"`        | trace/debug/info/warning/error/fatal/panic                           |
+| TimeFormat       | Time format to add to the S3 path     | `"20060102/15"` | Specify in [Go's Time Format](https://golang.org/src/time/format.go) | 
+| TimeZone         | Specify TimeZone                      | `""`            | Specify TZInfo based region. e.g.) Asia/Tokyo                        |
 
 Example:
 
@@ -93,6 +94,7 @@ Add this section to fluent-bit.conf:
     SecretAccessKey yourawssecretaccesskey
     Bucket          yourbucketname
     S3Prefix yours3prefixname
+    SuffixAlgorithm sha256
     Region us-east-1
     Compress gzip
     # Endpoint parameter is mainly used for minio.

--- a/out_s3.go
+++ b/out_s3.go
@@ -73,6 +73,7 @@ func (p *fluentPlugin) Exit(code int) {
 func (p *fluentPlugin) Put(s3operator *s3operator, objectKey string, timestamp time.Time, line string) error {
 	switch s3operator.compressFormat {
 	case plainTextFormat:
+		s3operator.logger.Tracef("[s3operator] objectKey = %s, rows = %d, byte = %d", objectKey, len(strings.Split(line, "\n")), len(line))
 		_, err := s3operator.uploader.Upload(&s3manager.UploadInput{
 			Bucket: aws.String(s3operator.bucket),
 			Key:    aws.String(objectKey),
@@ -81,6 +82,7 @@ func (p *fluentPlugin) Put(s3operator *s3operator, objectKey string, timestamp t
 		return err
 	case gzipFormat:
 		compressed, err := makeGzip([]byte(line))
+		s3operator.logger.Tracef("[s3operator] objectKey = %s, rows = %d, byte = %d", objectKey, len(strings.Split(line, "\n")), len(compressed))
 		if err != nil {
 			return err
 		}

--- a/out_s3.go
+++ b/out_s3.go
@@ -1,6 +1,11 @@
 package main
 
-import "github.com/fluent/fluent-bit-go/output"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"github.com/fluent/fluent-bit-go/output"
+)
 import "github.com/json-iterator/go"
 import "github.com/aws/aws-sdk-go/aws"
 import "github.com/aws/aws-sdk-go/aws/awserr"
@@ -30,13 +35,14 @@ func init() {
 }
 
 type s3operator struct {
-	bucket         string
-	prefix         string
-	uploader       *s3manager.Uploader
-	compressFormat format
-	logger         *log.Logger
-	timeFormat     string
-	location       *time.Location
+	bucket          string
+	prefix          string
+	suffixAlgorithm algorithm
+	uploader        *s3manager.Uploader
+	compressFormat  format
+	logger          *log.Logger
+	timeFormat      string
+	location        *time.Location
 }
 
 type GoOutputPlugin interface {
@@ -176,6 +182,7 @@ func newS3Output(ctx unsafe.Pointer, operatorID int) (*s3operator, error) {
 	secretAccessKey := plugin.PluginConfigKey(ctx, "SecretAccessKey")
 	bucket := plugin.PluginConfigKey(ctx, "Bucket")
 	s3prefix := plugin.PluginConfigKey(ctx, "S3Prefix")
+	suffixAlgorithm := plugin.PluginConfigKey(ctx, "SuffixAlgorithm")
 	region := plugin.PluginConfigKey(ctx, "Region")
 	compress := plugin.PluginConfigKey(ctx, "Compress")
 	endpoint := plugin.PluginConfigKey(ctx, "Endpoint")
@@ -184,7 +191,8 @@ func newS3Output(ctx unsafe.Pointer, operatorID int) (*s3operator, error) {
 	timeFormat := plugin.PluginConfigKey(ctx, "TimeFormat")
 	timeZone := plugin.PluginConfigKey(ctx, "TimeZone")
 
-	config, err := getS3Config(accessKeyID, secretAccessKey, credential, s3prefix, bucket, region, compress, endpoint, autoCreateBucket, logLevel, timeFormat, timeZone)
+	config, err := getS3Config(accessKeyID, secretAccessKey, credential, s3prefix, suffixAlgorithm, bucket, region, compress, endpoint, autoCreateBucket, logLevel, timeFormat, timeZone)
+
 	if err != nil {
 		return nil, err
 	}
@@ -196,6 +204,7 @@ func newS3Output(ctx unsafe.Pointer, operatorID int) (*s3operator, error) {
 	logger.Infof("[flb-go %d] plugin secretAccessKey parameter = '%s'", operatorID, obfuscateSecret(secretAccessKey))
 	logger.Infof("[flb-go %d] plugin bucket parameter = '%s'", operatorID, bucket)
 	logger.Infof("[flb-go %d] plugin s3prefix parameter = '%s'", operatorID, s3prefix)
+	logger.Infof("[flb-go %d] plugin suffixAlgorithm parameter = '%s'", operatorID, suffixAlgorithm)
 	logger.Infof("[flb-go %d] plugin region parameter = '%s'", operatorID, region)
 	logger.Infof("[flb-go %d] plugin compress parameter = '%s'", operatorID, compress)
 	logger.Infof("[flb-go %d] plugin endpoint parameter = '%s'", operatorID, endpoint)
@@ -231,13 +240,14 @@ func newS3Output(ctx unsafe.Pointer, operatorID int) (*s3operator, error) {
 	})
 
 	s3operator := &s3operator{
-		bucket:         *config.bucket,
-		prefix:         *config.s3prefix,
-		uploader:       uploader,
-		compressFormat: config.compress,
-		logger:         logger,
-		timeFormat:     config.timeFormat,
-		location:       config.location,
+		bucket:          *config.bucket,
+		prefix:          *config.s3prefix,
+		suffixAlgorithm: config.suffixAlgorithm,
+		uploader:        uploader,
+		compressFormat:  config.compress,
+		logger:          logger,
+		timeFormat:      config.timeFormat,
+		location:        config.location,
 	}
 
 	return s3operator, nil
@@ -306,7 +316,7 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 		lines += line + "\n"
 	}
 
-	objectKey := GenerateObjectKey(s3operator, time.Now())
+	objectKey := GenerateObjectKey(s3operator, time.Now(), lines)
 	err := plugin.Put(s3operator, objectKey, time.Now(), lines)
 	if err != nil {
 		s3operator.logger.Warnf("error sending message for S3: %v", err)
@@ -322,7 +332,7 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 }
 
 // format is S3_PREFIX/S3_TRAILING_PREFIX/date/hour/timestamp_uuid.log
-func GenerateObjectKey(s3operator *s3operator, t time.Time) string {
+func GenerateObjectKey(s3operator *s3operator, t time.Time, lines string) string {
 	var fileext string
 	switch s3operator.compressFormat {
 	case plainTextFormat:
@@ -330,11 +340,19 @@ func GenerateObjectKey(s3operator *s3operator, t time.Time) string {
 	case gzipFormat:
 		fileext = ".log.gz"
 	}
+	var suffix string
+	switch s3operator.suffixAlgorithm {
+	case noSuffixAlgorithm:
+		suffix = ""
+	case sha256SuffixAlgorithm:
+		b := sha256.Sum256([]byte(lines))
+		suffix = fmt.Sprintf("-%s", hex.EncodeToString(b[:]))
+	}
 	// Convert time.Time object's Local with specified TimeZone's
 	time.Local = s3operator.location
 	timestamp := t.Local().Format("20060102150405")
 
-	fileName := strings.Join([]string{timestamp, fileext}, "")
+	fileName := strings.Join([]string{timestamp, suffix, fileext}, "")
 
 	objectKey := filepath.Join(s3operator.prefix, t.Local().Format(s3operator.timeFormat), fileName)
 	return objectKey

--- a/out_s3_test.go
+++ b/out_s3_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 	"unsafe"
@@ -96,9 +97,40 @@ func TestGenerateObjectKey(t *testing.T) {
 		uploader:       nil,
 		compressFormat: plainTextFormat,
 	}
-	objectKey := GenerateObjectKey(s3mock, now)
+	lines := "exampletext"
+	objectKey := GenerateObjectKey(s3mock, now, lines)
 	fmt.Printf("objectKey: %v\n", objectKey)
 	assert.NotNil(t, objectKey, "objectKey not to be nil")
+}
+
+func TestGenerateObjectKeyWithNoSuffixAlgorithm(t *testing.T) {
+	now := time.Now()
+	s3mock := &s3operator{
+		bucket:          "s3examplebucket",
+		prefix:          "s3exampleprefix",
+		suffixAlgorithm: noSuffixAlgorithm,
+		uploader:        nil,
+		compressFormat:  plainTextFormat,
+	}
+	lines := "exampletext"
+	objectKey := GenerateObjectKey(s3mock, now, lines)
+	fmt.Printf("objectKey: %v\n", objectKey)
+	assert.False(t, strings.HasSuffix(objectKey, "-c675f9cd0e59479e5ccca3ea8a03beccd80f662f6a56662bfc9dd0b61d4f73c3.log"), "objectKey has no suffix")
+}
+
+func TestGenerateObjectKeyWithSha256SuffixAlgorithm(t *testing.T) {
+	now := time.Now()
+	s3mock := &s3operator{
+		bucket:          "s3examplebucket",
+		prefix:          "s3exampleprefix",
+		suffixAlgorithm: sha256SuffixAlgorithm,
+		uploader:        nil,
+		compressFormat:  plainTextFormat,
+	}
+	lines := "exampletext"
+	objectKey := GenerateObjectKey(s3mock, now, lines)
+	fmt.Printf("objectKey: %v\n", objectKey)
+	assert.True(t, strings.HasSuffix(objectKey, "-c675f9cd0e59479e5ccca3ea8a03beccd80f662f6a56662bfc9dd0b61d4f73c3.log"), "objectKey has sha256 suffix")
 }
 
 func TestGenerateObjectKeyWithTokyoLocation(t *testing.T) {
@@ -111,7 +143,8 @@ func TestGenerateObjectKeyWithTokyoLocation(t *testing.T) {
 		compressFormat: plainTextFormat,
 		location:       loc,
 	}
-	objectKey := GenerateObjectKey(s3mock, now)
+	lines := "exampletext"
+	objectKey := GenerateObjectKey(s3mock, now, lines)
 	fmt.Printf("objectKey: %v\n", objectKey)
 	assert.NotNil(t, objectKey, "objectKey not to be nil")
 }
@@ -126,7 +159,8 @@ func TestGenerateObjectKeyWithUSEastLocation(t *testing.T) {
 		compressFormat: plainTextFormat,
 		location:       loc,
 	}
-	objectKey := GenerateObjectKey(s3mock, now)
+	lines := "exampletext"
+	objectKey := GenerateObjectKey(s3mock, now, lines)
 	fmt.Printf("objectKey: %v\n", objectKey)
 	assert.NotNil(t, objectKey, "objectKey not to be nil")
 }
@@ -141,7 +175,8 @@ func TestGenerateObjectKeyWithUTCLocation(t *testing.T) {
 		compressFormat: plainTextFormat,
 		location:       loc,
 	}
-	objectKey := GenerateObjectKey(s3mock, now)
+	lines := "exampletext"
+	objectKey := GenerateObjectKey(s3mock, now, lines)
 	fmt.Printf("objectKey: %v\n", objectKey)
 	assert.NotNil(t, objectKey, "objectKey not to be nil")
 }
@@ -154,7 +189,8 @@ func TestGenerateObjectKeyWithGzip(t *testing.T) {
 		uploader:       nil,
 		compressFormat: gzipFormat,
 	}
-	objectKey := GenerateObjectKey(s3mock, now)
+	lines := "exampletext"
+	objectKey := GenerateObjectKey(s3mock, now, lines)
 	fmt.Printf("objectKey: %v\n", objectKey)
 	assert.NotNil(t, objectKey, "objectKey not to be nil")
 }
@@ -297,7 +333,7 @@ func (c *testS3Credential) GetCredentials(accessID, secretkey, credential string
 
 func TestPluginInitializationWithStaticCredentials(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "examplebucket", "exampleregion", "", "", "false", "info", "", "")
+	_, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "", "examplebucket", "exampleregion", "", "", "false", "info", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -318,7 +354,7 @@ func TestPluginInitializationWithStaticCredentials(t *testing.T) {
 
 func TestPluginInitializationWithSharedCredentials(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "", "", "false", "info", "", "")
+	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "", "examplebucket", "exampleregion", "", "", "false", "info", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}

--- a/s3.go
+++ b/s3.go
@@ -20,10 +20,18 @@ const (
 	gzipFormat
 )
 
+type algorithm int
+
+const (
+	noSuffixAlgorithm algorithm = iota
+	sha256SuffixAlgorithm
+)
+
 type s3Config struct {
 	credentials      *credentials.Credentials
 	bucket           *string
 	s3prefix         *string
+	suffixAlgorithm  algorithm
 	region           *string
 	compress         format
 	endpoint         string
@@ -60,7 +68,7 @@ func (c *s3PluginConfig) GetCredentials(accessKeyID, secretKey, credential strin
 	return nil, nil
 }
 
-func getS3Config(accessID, secretKey, credential, s3prefix, bucket, region, compress, endpoint, autoCreateBucket, logLevel, timeFormat, timeZone string) (*s3Config, error) {
+func getS3Config(accessID, secretKey, credential, s3prefix, suffixAlgorithm, bucket, region, compress, endpoint, autoCreateBucket, logLevel, timeFormat, timeZone string) (*s3Config, error) {
 	conf := &s3Config{}
 	creds, err := s3Creds.GetCredentials(accessID, secretKey, credential)
 	if err != nil {
@@ -77,6 +85,13 @@ func getS3Config(accessID, secretKey, credential, s3prefix, bucket, region, comp
 		return nil, fmt.Errorf("Cannot specify empty string to s3prefix")
 	}
 	conf.s3prefix = aws.String(s3prefix)
+
+	switch suffixAlgorithm {
+	case "sha256":
+		conf.suffixAlgorithm = sha256SuffixAlgorithm
+	default:
+		conf.suffixAlgorithm = noSuffixAlgorithm
+	}
 
 	if region == "" {
 		return nil, fmt.Errorf("Cannot specify empty string to region")

--- a/s3_test.go
+++ b/s3_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGetS3ConfigStaticCredentials(t *testing.T) {
-	conf, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "examplebucket", "exampleregion", "", "", "", "", "", "")
+	conf, err := getS3Config("exampleaccessID", "examplesecretkey", "", "exampleprefix", "", "examplebucket", "exampleregion", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -23,7 +23,7 @@ func TestGetS3ConfigStaticCredentials(t *testing.T) {
 
 func TestGetS3ConfigSharedCredentials(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "", "", "", "", "", "")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "", "examplebucket", "exampleregion", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -38,7 +38,7 @@ func TestGetS3ConfigSharedCredentials(t *testing.T) {
 
 func TestGetS3ConfigCompression(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "", "")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "", "examplebucket", "exampleregion", "gzip", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -53,7 +53,7 @@ func TestGetS3ConfigCompression(t *testing.T) {
 
 func TestGetS3ConfigEndpoint(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "http://localhost:9000", "false", "", "", "")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "", "examplebucket", "exampleregion", "gzip", "http://localhost:9000", "false", "", "", "")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -69,7 +69,7 @@ func TestGetS3ConfigEndpoint(t *testing.T) {
 
 func TestGetS3ConfigInvalidEndpoint(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "https://your-bucketname.s3.amazonaws.com", "false", "", "", "")
+	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "", "examplebucket", "exampleregion", "gzip", "https://your-bucketname.s3.amazonaws.com", "false", "", "", "")
 	if err != nil {
 		expected := errors.New("Endpoint is not supported for AWS S3. This parameter is intended for S3 compatible services. Use Region instead.")
 		assert.Equal(t, expected, err)
@@ -78,7 +78,7 @@ func TestGetS3ConfigInvalidEndpoint(t *testing.T) {
 
 func TestGetS3ConfigTimeFormat(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "dt=2006-01-02", "Asia/Tokyo")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "", "examplebucket", "exampleregion", "gzip", "", "", "", "dt=2006-01-02", "Asia/Tokyo")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -96,7 +96,7 @@ func TestGetS3ConfigTimeFormat(t *testing.T) {
 
 func TestGetS3ConfigTimeZone(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "", "Asia/Tokyo")
+	conf, err := getS3Config("", "", "examplecredentials", "exampleprefix", "", "examplebucket", "exampleregion", "gzip", "", "", "", "", "Asia/Tokyo")
 	if err != nil {
 		t.Fatalf("failed test %#v", err)
 	}
@@ -114,7 +114,7 @@ func TestGetS3ConfigTimeZone(t *testing.T) {
 
 func TestGetS3ConfigInvalidTimeZone(t *testing.T) {
 	s3Creds = &testS3Credential{}
-	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "examplebucket", "exampleregion", "gzip", "", "", "", "", "Asia/Nonexistent")
+	_, err := getS3Config("", "", "examplecredentials", "exampleprefix", "", "examplebucket", "exampleregion", "gzip", "", "", "", "", "Asia/Nonexistent")
 	if err != nil {
 		expected := errors.New("invalid timeZone: unknown time zone Asia/Nonexistent")
 		assert.Equal(t, expected, err)


### PR DESCRIPTION
I added a trace log and checked it, and then put it to the same object key is happening.

```
time="2020-03-28T01:05:24+09:00" level=trace msg="[s3operator] objectKey = fluent-bit/dt=2020-03-28/20200328010524.log, rows = 17, byte = 26436"
time="2020-03-28T01:05:24+09:00" level=trace msg="[s3operator] objectKey = fluent-bit/dt=2020-03-28/20200328010524.log, rows = 61, byte = 118943"
time="2020-03-28T01:05:24+09:00" level=trace msg="[s3operator] objectKey = fluent-bit/dt=2020-03-28/20200328010524.log, rows = 30, byte = 55433"
```

This problem causes some logs to be lost.

~~So I added a UUID to the file name suffix.~~
~~I decided to use UUID because I thought it was the most secure of the following options.~~

1. ~~Existence check-in S3~~
    - ~~This doesn't cause duplication, but it does slow down throughput~~
2. ~~Add a suffix of count number~~
    - ~~It works in one process but duplicates in multiple processes~~
3. ~~Add a suffix of sha256~~
    - ~~Duplicates are rare but the character length is very long~~
4. ~~Add a suffix of UUID~~
    - ~~Duplicates are rare and do not slow down throughput as much as S3 existence checks~~

**Update**: Allow configuration parameters to select `sha256` or `no suffix`.
This will prevent object key collisions.

```
[OUTPUT]
    Name            s3
    Match           kube.*
    Bucket          mybuckets
    S3Prefix        path/to
    SuffixAlgorithm sha256
    Region          ap-northeast-1
    Compress        gzip
```

If `SuffixAlgorithm` is empty or omitted, no suffix will be given.
The default is empty.

### Test cases

I have checked to work with EKS v1.14 and fluent-bit v1.3.11.

```
time="2020-03-28T19:14:18+09:00" level=trace msg="[s3operator] objectKey = fluent-bit/dt=2020-03-28/20200328191418-e97b0092433e9da22e1631e332696e12b367f86416e97fdbbfc2518274c87a06.log, rows = 38, byte = 41308"
time="2020-03-28T19:14:18+09:00" level=trace msg="[s3operator] objectKey = fluent-bit/dt=2020-03-28/20200328191418-be30d54b62a32bf08562c4e6d2fd0505a9a8a242d142c18776b6811ce0e1d559.log, rows = 2, byte = 930"
time="2020-03-28T19:14:18+09:00" level=trace msg="[s3operator] objectKey = fluent-bit/dt=2020-03-28/20200328191418-d786a9e7fb87bb7c819d1c45e8a9ff5b1d8c02de565062da6d315f6b7d061fa5.log, rows = 2, byte = 937"
```