### PR TITLE
[docker] Offer FLUENT_BIT_SUFFIX_ALGORITHM

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ docker run -it -e="FLUENT_BIT_ACCESS_KEY_ID=yourawsaccesskey" \
                  -e="FLUENT_BIT_BUCKET_NAME=yourbucketname" \
                  -e="FLUENT_BIT_S3_PREFIX=yours3prefix" \
                  -e="FLUENT_BIT_REGION=awsregion" \
+                 -e "FLUENT_BIT_SUFFIX_ALGORITHM=algorithm" \
                  fluent-bit/s3-plugin
 ```
 

--- a/docker/fluent-bit-s3.conf
+++ b/docker/fluent-bit-s3.conf
@@ -46,4 +46,5 @@
     Bucket          ${FLUENT_BIT_BUCKET_NAME}
     S3Prefix        ${FLUENT_BIT_S3_PREFIX}
     Region          ${FLUENT_BIT_REGION}
+    SuffixAlgorithm ${FLUENT_BIT_SUFFIX_ALGORITHM}
     # TimeZone       Asia/Tokyo


### PR DESCRIPTION
## Description

Offer `FLUENT_BIT_SUFFIX_ALGORITHM` envvar in docker.

## Why

There is an explicit warn about this from logs:
```
[ warn] [flb-go 0] Not using suffix algorithm will cause object key collision. Please consider to use `suffixAlgorithm sha256`.
```